### PR TITLE
Chore: Add Anchor API step to trigger NHN Pipeline

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -91,3 +91,21 @@ jobs:
           set -eux
           docker push $REGISTRY/$IMAGE_NAME:dev-$SHA7
           docker push $REGISTRY/$IMAGE_NAME:dev-latest
+
+      - name: Execute NHN Cloud Pipeline via Anchor API (dev)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
+        env:
+          NHN_REGION: KR1
+          NHN_APPKEY: ${{ secrets.NHN_APPKEY }}
+          NHN_AUTH_ID: ${{ secrets.NHN_USER_ACCESS_KEY_ID }}
+          NHN_AUTH_SECRET: ${{ secrets.NHN_USER_ACCESS_KEY_SECRET }}
+          NHN_PIPELINE: contest11-dev-pipeline
+        run: |
+          set -eux
+          curl --fail --show-error --location --max-time 20 -i -X POST \
+            -H "Content-Type:application/json" \
+            -H "X-NHN-REGION:KR1" \
+            -H "X-TC-AUTHENTICATION-ID:${NHN_AUTH_ID}" \
+            -H "X-TC-AUTHENTICATION-SECRET:${NHN_AUTH_SECRET}" \
+            -H "X-NHN-APPKEY:${NHN_APPKEY}" \
+            "https://kr1-pipeline.api.nhncloudservice.com/api/anchor/v1.0/pipelines/${NHN_PIPELINE}/execute"


### PR DESCRIPTION
## 요약
Docker 이미지 푸시 이후 NHN Cloud Pipeline을 Anchor API로 실행하는 스텝 추가

<br>

## 작업 내용
- develop 브랜치 push 시 Anchor API를 호출하여 파이프라인 자동 실행
- API 요청 시 필요한 헤더(X-NHN-REGION, X-NHN-APPKEY, X-TC-AUTHENTICATION-ID/SECRET) 포함
- GitHub Secrets로 APPKEY, User Access Key ID/Secret
<br>

## 참고 사항
- 기존 Docker Hub 이미지 저장소 자동 실행 대신 API 실행 방식으로 전환

<br>

## 관련 이슈

<br>