### PR TITLE
Chore: Add Helm charts for MSA services deployment

### DIFF
--- a/charts/spot-service/Chart.yaml
+++ b/charts/spot-service/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: spot-service
+description: Spot service for photo-spot app
+type: application
+version: 0.1.0          # <- CI에서 자동 갱신
+appVersion: "1.0.0"

--- a/charts/spot-service/templates/_helpers.tpl
+++ b/charts/spot-service/templates/_helpers.tpl
@@ -1,0 +1,49 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "spot-service.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "spot-service.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "spot-service.labels" -}}
+helm.sh/chart: {{ include "spot-service.chart" . }}
+{{ include "spot-service.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "spot-service.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "spot-service.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "spot-service.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}

--- a/charts/spot-service/templates/deployment.yaml
+++ b/charts/spot-service/templates/deployment.yaml
@@ -1,0 +1,18 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "spot-service.fullname" . }}
+  labels: {{- include "spot-service.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels: {{- include "spot-service.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels: {{- include "spot-service.selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: app
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          ports:
+            - containerPort: 8082

--- a/charts/spot-service/templates/service.yaml
+++ b/charts/spot-service/templates/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "spot-service.fullname" . }}
+  labels: {{- include "spot-service.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  selector: {{- include "spot-service.selectorLabels" . | nindent 4 }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: 8082

--- a/charts/spot-service/values.yaml
+++ b/charts/spot-service/values.yaml
@@ -1,0 +1,8 @@
+image:
+  repository: docker.io/gemmap/spot-service
+  tag: dev-latest # 기본 태그(오버라이드로 바꿀 수 있음)
+replicaCount: 1
+service:
+  type: ClusterIP
+  port: 8082
+resources: {}

--- a/charts/user-service/Chart.yaml
+++ b/charts/user-service/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: user-service
+description: User service for photo-spot app
+type: application
+version: 0.1.0          # <- CI에서 자동 갱신
+appVersion: "1.0.0"

--- a/charts/user-service/templates/_helpers.tpl
+++ b/charts/user-service/templates/_helpers.tpl
@@ -1,0 +1,49 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "user-service.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "user-service.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "user-service.labels" -}}
+helm.sh/chart: {{ include "user-service.chart" . }}
+{{ include "user-service.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "user-service.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "user-service.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "user-service.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}

--- a/charts/user-service/templates/deployment.yaml
+++ b/charts/user-service/templates/deployment.yaml
@@ -1,0 +1,18 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "user-service.fullname" . }}
+  labels: {{- include "user-service.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels: {{- include "user-service.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels: {{- include "user-service.selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: app
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          ports:
+            - containerPort: 8081

--- a/charts/user-service/templates/service.yaml
+++ b/charts/user-service/templates/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "user-service.fullname" . }}
+  labels: {{- include "user-service.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  selector: {{- include "user-service.selectorLabels" . | nindent 4 }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: 8081

--- a/charts/user-service/values.yaml
+++ b/charts/user-service/values.yaml
@@ -1,0 +1,8 @@
+image:
+  repository: docker.io/gemmap/user-service
+  tag: dev-latest # 기본 태그(오버라이드로 바꿀 수 있음)
+replicaCount: 1
+service:
+  type: ClusterIP
+  port: 8081
+resources: {}


### PR DESCRIPTION
## 요약
User-service와 Spot-service의 Kubernetes 배포를 위한 Helm 차트를 추가.

<br>

## 작업 내용
- charts/user-service 및 charts/spot-service Helm 차트 디렉터리 추가
- 각 차트에 Chart.yaml, values.yaml 설정 파일 구성
- Deployment 및 Service 템플릿 추가 (_helpers.tpl 포함)
- 서비스별 포트 설정: user-service(8081), spot-service(8082)
- 이미지 레포지토리: docker.io/gemmap/{service-name}
- 기본 이미지 태그: dev-latest (CI/CD에서 오버라이드 가능)

<br>

## 참고 사항
- Chart.yaml의 version 필드는 CI/CD 파이프라인에서 자동 갱신 예정
- values.yaml의 image.tag는 배포 시 동적으로 오버라이드 가능
- 기존 k8s/base 매니페스트와 동일한 포트 설정 유지
- ClusterIP 타입 서비스로 구성 (내부 통신용)

<br>

## 관련 이슈

<br>