### PR TITLE
Chore(ci): Add Helm chart auto-versioning and release workflow

### DIFF
--- a/.github/workflows/build-spot-service.yml
+++ b/.github/workflows/build-spot-service.yml
@@ -119,3 +119,12 @@ jobs:
             -H "X-TC-AUTHENTICATION-SECRET:${NHN_AUTH_SECRET}" \
             -H "X-NHN-APPKEY:${NHN_APPKEY}" \
             "https://kr1-pipeline.api.nhncloudservice.com/api/anchor/v1.0/pipelines/${NHN_PIPELINE}/execute"
+
+      - name: Bump spot-service chart version
+        if: success()
+        run: |
+          sed -i "s/^version: .*/version: 0.1.${GITHUB_RUN_NUMBER}/" charts/spot-service/Chart.yaml
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git commit -am "chore(spot-chart): bump 0.1.${GITHUB_RUN_NUMBER}" || true
+          git push

--- a/.github/workflows/build-user-service.yml
+++ b/.github/workflows/build-user-service.yml
@@ -119,3 +119,12 @@ jobs:
             -H "X-TC-AUTHENTICATION-SECRET:${NHN_AUTH_SECRET}" \
             -H "X-NHN-APPKEY:${NHN_APPKEY}" \
             "https://kr1-pipeline.api.nhncloudservice.com/api/anchor/v1.0/pipelines/${NHN_PIPELINE}/execute"
+
+      - name: Bump user-service chart version
+        if: success()
+        run: |
+          sed -i "s/^version: .*/version: 0.1.${GITHUB_RUN_NUMBER}/" charts/user-service/Chart.yaml
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git commit -am "chore(user-chart): bump 0.1.${GITHUB_RUN_NUMBER}" || true
+          git push

--- a/.github/workflows/release-charts.yml
+++ b/.github/workflows/release-charts.yml
@@ -1,0 +1,33 @@
+# .github/workflows/release-charts.yml
+name: Release Helm Charts
+on:
+  push:
+    branches: [develop]
+    paths: ['charts/**']
+  workflow_dispatch: {} # (옵션) 수동 실행 허용
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
+      - uses: azure/setup-helm@v4
+      # (옵션) 간단 버전 증가
+      - name: Bump chart versions
+        run: |
+          for c in charts/*/Chart.yaml; do
+            sed -i "s/^version: .*/version: 0.1.${GITHUB_RUN_NUMBER}/" "$c"
+          done
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git commit -am "chore(charts): bump to 0.1.${GITHUB_RUN_NUMBER}" || true
+      - name: Release charts (.tgz + update gh-pages/index.yaml)
+        uses: helm/chart-releaser-action@v1.7.0
+        with:
+          charts_dir: charts
+        env:
+          CR_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## 요약
서비스 빌드 시 Helm 차트 버전을 자동으로 업데이트하고, 차트를 릴리스하는 GitHub Actions 워크플로우를 추가.

<br>

## 작업 내용
- build-user-service.yml에 차트 버전 자동 증가 스텝 추가
- build-spot-service.yml에 차트 버전 자동 증가 스텝 추가
- release-charts.yml 워크플로우 추가 (charts/** 변경 시 트리거)
- 각 서비스 빌드 성공 시 해당 차트의 Chart.yaml 버전 자동 업데이트
- 차트 버전 형식: 0.1.<GITHUB_RUN_NUMBER>
- helm/chart-releaser-action을 사용한 차트 패키징 및 릴리스
- gh-pages 브랜치에 index.yaml 자동 업데이트

<br>

## 참고 사항
- 서비스 빌드 성공 시 자동으로 해당 차트 버전이 업데이트됩니다
- charts/** 경로 변경 시 release-charts.yml 워크플로우가 트리거됩니다
- gh-pages 브랜치는 Helm repository로 사용 가능합니다
- helm repo add 명령어로 이 저장소를 Helm 레포지토리로 추가 가능
- workflow_dispatch로 수동 실행도 가능
- 차트 버전과 서비스 배포가 자동으로 동기화

<br>

## 관련 이슈

<br>