### PR TITLE
Chore(ci): Refactor chart release workflow

### DIFF
--- a/.github/workflows/build-spot-service.yml
+++ b/.github/workflows/build-spot-service.yml
@@ -101,30 +101,3 @@ jobs:
           set -eux
           docker push $REGISTRY/$IMAGE_NAME:dev-$SHA7
           docker push $REGISTRY/$IMAGE_NAME:dev-latest
-
-      - name: Execute NHN Pipeline - spot-service (dev)
-        if: github.ref == 'refs/heads/develop'
-        env:
-          NHN_REGION: KR1
-          NHN_APPKEY: ${{ secrets.NHN_APPKEY }}
-          NHN_AUTH_ID: ${{ secrets.NHN_USER_ACCESS_KEY_ID }}
-          NHN_AUTH_SECRET: ${{ secrets.NHN_USER_ACCESS_KEY_SECRET }}
-          NHN_PIPELINE: contest11-dev-pipeline-2
-        run: |
-          set -eux
-          curl --fail --show-error --location --max-time 20 -i -X POST \
-            -H "Content-Type:application/json" \
-            -H "X-NHN-REGION:${NHN_REGION}" \
-            -H "X-TC-AUTHENTICATION-ID:${NHN_AUTH_ID}" \
-            -H "X-TC-AUTHENTICATION-SECRET:${NHN_AUTH_SECRET}" \
-            -H "X-NHN-APPKEY:${NHN_APPKEY}" \
-            "https://kr1-pipeline.api.nhncloudservice.com/api/anchor/v1.0/pipelines/${NHN_PIPELINE}/execute"
-
-      - name: Bump spot-service chart version
-        if: success()
-        run: |
-          sed -i "s/^version: .*/version: 0.1.${GITHUB_RUN_NUMBER}/" charts/spot-service/Chart.yaml
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git commit -am "chore(spot-chart): bump 0.1.${GITHUB_RUN_NUMBER}" || true
-          git push

--- a/.github/workflows/build-user-service.yml
+++ b/.github/workflows/build-user-service.yml
@@ -101,30 +101,3 @@ jobs:
           set -eux
           docker push $REGISTRY/$IMAGE_NAME:dev-$SHA7
           docker push $REGISTRY/$IMAGE_NAME:dev-latest
-
-      - name: Execute NHN Pipeline - user-service (dev)
-        if: github.ref == 'refs/heads/develop'
-        env:
-          NHN_REGION: KR1
-          NHN_APPKEY: ${{ secrets.NHN_APPKEY }}
-          NHN_AUTH_ID: ${{ secrets.NHN_USER_ACCESS_KEY_ID }}
-          NHN_AUTH_SECRET: ${{ secrets.NHN_USER_ACCESS_KEY_SECRET }}
-          NHN_PIPELINE: contest11-dev-pipeline-1
-        run: |
-          set -eux
-          curl --fail --show-error --location --max-time 20 -i -X POST \
-            -H "Content-Type:application/json" \
-            -H "X-NHN-REGION:${NHN_REGION}" \
-            -H "X-TC-AUTHENTICATION-ID:${NHN_AUTH_ID}" \
-            -H "X-TC-AUTHENTICATION-SECRET:${NHN_AUTH_SECRET}" \
-            -H "X-NHN-APPKEY:${NHN_APPKEY}" \
-            "https://kr1-pipeline.api.nhncloudservice.com/api/anchor/v1.0/pipelines/${NHN_PIPELINE}/execute"
-
-      - name: Bump user-service chart version
-        if: success()
-        run: |
-          sed -i "s/^version: .*/version: 0.1.${GITHUB_RUN_NUMBER}/" charts/user-service/Chart.yaml
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git commit -am "chore(user-chart): bump 0.1.${GITHUB_RUN_NUMBER}" || true
-          git push

--- a/.github/workflows/release-charts.yml
+++ b/.github/workflows/release-charts.yml
@@ -1,33 +1,87 @@
 # .github/workflows/release-charts.yml
 name: Release Helm Charts
+
 on:
-  push:
-    branches: [develop]
-    paths: ['charts/**']
-  workflow_dispatch: {} # (옵션) 수동 실행 허용
+  workflow_run:
+    workflows:
+      - Build & Deploy User Service
+      - Build & Deploy Spot Service
+    types: [completed]
+  workflow_dispatch: {}   # (옵션) 수동 실행 허용
 
 permissions:
-  contents: write
+  contents: read          # 쓰기는 PAT로 수행
+
+concurrency:
+  group: release-charts
+  cancel-in-progress: false
 
 jobs:
   release:
+    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
+    env:
+      CHART_BASE_URL: https://we-are-maker.github.io/gemmap-backend/
     steps:
       - uses: actions/checkout@v4
-        with: { fetch-depth: 0 }
+        with:
+          fetch-depth: 0
+
       - uses: azure/setup-helm@v4
-      # (옵션) 간단 버전 증가
-      - name: Bump chart versions
+
+      # 어떤 워크플로가 끝났는지에 따라 대상 서비스 결정 (user/spot)
+      - name: Detect built service
+        id: svc
         run: |
-          for c in charts/*/Chart.yaml; do
-            sed -i "s/^version: .*/version: 0.1.${GITHUB_RUN_NUMBER}/" "$c"
-          done
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git commit -am "chore(charts): bump to 0.1.${GITHUB_RUN_NUMBER}" || true
+          N="${{ github.event.workflow_run.name }}"
+          if echo "$N" | grep -qi "User Service"; then
+            echo "name=user-service"   >> $GITHUB_OUTPUT
+            echo "chart_dir=charts/user-service" >> $GITHUB_OUTPUT
+            echo "pipeline_id=contest11-dev-pipeline-1" >> $GITHUB_OUTPUT
+          elif echo "$N" | grep -qi "Spot Service"; then
+            echo "name=spot-service"   >> $GITHUB_OUTPUT
+            echo "chart_dir=charts/spot-service" >> $GITHUB_OUTPUT
+            echo "pipeline_id=contest11-dev-pipeline-2" >> $GITHUB_OUTPUT
+          else
+            echo "Unknown workflow: $N"; exit 1
+          fi
+
+      # 커밋 없이 '로컬 파일'의 버전만 변경 (둘 중 해당 서비스만 변경)
+      - name: Set chart version (no commit)
+        run: |
+          V="0.1.${GITHUB_RUN_NUMBER}"
+          sed -i "s/^version: .*/version: ${V}/" "${{ steps.svc.outputs.chart_dir }}/Chart.yaml"
+          echo "VERSION=${V}" >> $GITHUB_ENV
+
+      # PAT로 릴리스 + gh-pages/index.yaml 갱신
       - name: Release charts (.tgz + update gh-pages/index.yaml)
         uses: helm/chart-releaser-action@v1.7.0
         with:
           charts_dir: charts
         env:
-          CR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CR_TOKEN: ${{ secrets.CHARTS_PAT }}
+
+      # index.yaml에 이번 버전이 반영될 때까지 짧게 폴링 (레이스 방지)
+      - name: Wait index.yaml updated
+        run: |
+          set -eux
+          for i in {1..30}; do
+            curl -fsSL "$CHART_BASE_URL/index.yaml" | grep "${VERSION}" && break || sleep 2
+          done
+
+      # NHN Pipeline Anchor: 차트 발행 이후에 트리거하여 순서 보장
+      - name: Execute NHN Pipeline (dev)
+        env:
+          NHN_REGION: KR1
+          NHN_APPKEY: ${{ secrets.NHN_APPKEY }}
+          NHN_AUTH_ID: ${{ secrets.NHN_USER_ACCESS_KEY_ID }}
+          NHN_AUTH_SECRET: ${{ secrets.NHN_USER_ACCESS_KEY_SECRET }}
+        run: |
+          set -eux
+          curl --fail --show-error --location --max-time 30 -i -X POST \
+            -H "Content-Type:application/json" \
+            -H "X-NHN-REGION:${NHN_REGION}" \
+            -H "X-TC-AUTHENTICATION-ID:${NHN_AUTH_ID}" \
+            -H "X-TC-AUTHENTICATION-SECRET:${NHN_AUTH_SECRET}" \
+            -H "X-NHN-APPKEY:${NHN_APPKEY}" \
+            "https://kr1-pipeline.api.nhncloudservice.com/api/anchor/v1.0/pipelines/${{ steps.svc.outputs.pipeline_id }}/execute"

--- a/.github/workflows/release-charts.yml
+++ b/.github/workflows/release-charts.yml
@@ -7,6 +7,8 @@ on:
       - Build & Deploy User Service
       - Build & Deploy Spot Service
     types: [completed]
+    branches:
+      - develop
   workflow_dispatch: {}   # (옵션) 수동 실행 허용
 
 permissions:
@@ -18,7 +20,13 @@ concurrency:
 
 jobs:
   release:
-    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event.workflow_run.event == 'push' &&
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.head_branch == 'develop'
+      )
     runs-on: ubuntu-latest
     env:
       CHART_BASE_URL: https://we-are-maker.github.io/gemmap-backend/


### PR DESCRIPTION
## 요약
Helm 차트 릴리스 워크플로를 개선하여 서비스 빌드 완료 후 자동으로 차트 릴리스 및 배포가 순차적으로 진행되도록 구조를 개선.

<br>

## 작업 내용
- **서비스 빌드 워크플로 간소화**
  - `build-user-service.yml`, `build-spot-service.yml`에서 NHN Pipeline 실행 단계 제거
  - 차트 버전 자동 증가 및 git commit/push 로직 제거

- **차트 릴리스 워크플로 개선**
  - `workflow_run` 트리거로 변경하여 서비스 빌드 완료 시 자동 실행
  - 빌드된 서비스 자동 감지 로직 추가 (user-service/spot-service 구분)
  - 차트 버전을 커밋 없이 로컬 파일에서만 변경
  - PAT (`CHARTS_PAT`) 사용으로 권한 문제 해결
  - `index.yaml` 업데이트 대기 로직 추가 (레이스 컨디션 방지)
  - NHN Pipeline 트리거를 차트 릴리스 이후로 이동
  - `concurrency` 설정으로 동시 실행 방지

<br>

## 참고 사항
- 이전에는 각 서비스 빌드 워크플로에서 차트 버전을 커밋하고 NHN Pipeline을 트리거했으나,
  이로 인해 차트 릴리스와 배포 순서가 보장되지 않는 문제가 있었음.
- 개선된 구조에서는 `release-charts` 워크플로가 중앙에서 차트 릴리스와 배포를 관리하여
  순서를 보장하고, 불필요한 git 커밋을 줄임.
- `CHARTS_PAT` 시크릿이 GitHub Actions Secrets에 등록되어 있어야 함.

<br>

## 관련 이슈

<br>