### PR TITLE
Chore(ci): Add push trigger to release-charts workflow

### DIFF
--- a/.github/workflows/release-charts.yml
+++ b/.github/workflows/release-charts.yml
@@ -6,8 +6,12 @@ on:
       - Build & Deploy User Service
       - Build & Deploy Spot Service
     types: [completed]
-    branches:
-      - develop
+    branches: [develop]    # 빌드 워크플로가 주로 develop에서 돌면 유지
+    push:
+      branches: [develop]    # Default branch로
+      paths:
+        - '.github/workflows/release-charts.yml'  # 워크플로 수정 시 바로 테스트
+        - 'charts/**'                             # charts 변경만으로도 릴리스
   workflow_dispatch: {}   # (옵션) 수동 실행 허용
 
 permissions:


### PR DESCRIPTION
## 요약
release-charts 워크플로에 push 트리거를 추가하여 차트나 워크플로 파일이 직접 수정될 때도 자동으로 릴리스가 실행되도록 개선.

<br>

## 작업 내용
- **push 트리거 추가**
  - develop 브랜치에 대한 push 이벤트 추가
  - paths 필터 설정: `.github/workflows/release-charts.yml`, `charts/**`

- **워크플로 테스트 개선**
  - 워크플로 파일 수정 시 바로 실행되어 변경사항 검증 가능

- **차트 직접 수정 대응**
  - 서비스 빌드 없이 차트만 수정되는 경우에도 릴리스 자동 실행
  - 차트 값 조정, 템플릿 수정 등의 경우 즉시 반영

<br>

## 참고 사항
- 기존에는 workflow_run 트리거만 있어서 서비스 빌드가 완료된 후에만 차트 릴리스가 실행되었음
- 이제는 차트 파일이나 워크플로 자체를 수정하고 develop에 푸시하면 바로 릴리스가 실행됨.

<br>

## 관련 이슈

<br>