### PR TITLE
Fix(ci): Enhance release-charts workflow for multi-service support

### DIFF
--- a/.github/workflows/release-charts.yml
+++ b/.github/workflows/release-charts.yml
@@ -6,8 +6,12 @@ on:
       - Build & Deploy User Service
       - Build & Deploy Spot Service
     types: [completed]
-    branches:
-      - develop
+    branches: [develop]    # 빌드 워크플로가 주로 develop에서 돌면 유지
+    push:
+      branches: [develop]    # Default branch로
+      paths:
+        - '.github/workflows/release-charts.yml'  # 워크플로 수정 시 바로 테스트
+        - 'charts/**'                             # charts 변경만으로도 릴리스
   workflow_dispatch: {}   # (옵션) 수동 실행 허용
 
 permissions:

--- a/.github/workflows/release-charts.yml
+++ b/.github/workflows/release-charts.yml
@@ -6,13 +6,20 @@ on:
       - Build & Deploy User Service
       - Build & Deploy Spot Service
     types: [completed]
-    branches: [develop]    # 빌드 워크플로가 주로 develop에서 돌면 유지
-    push:
-      branches: [develop]    # Default branch로
-      paths:
-        - '.github/workflows/release-charts.yml'  # 워크플로 수정 시 바로 테스트
-        - 'charts/**'                             # charts 변경만으로도 릴리스
-  workflow_dispatch: {}   # (옵션) 수동 실행 허용
+    branches: [develop]
+  workflow_dispatch:
+    inputs:
+      service:
+        description: 'Which chart(s) to release?'
+        type: choice
+        required: false
+        options: [user-service, spot-service, both]
+        default: both
+  push:
+    branches: [develop]
+    paths:
+      - 'charts/**'
+      - '.github/workflows/release-charts.yml'
 
 permissions:
   contents: read          # 쓰기는 PAT로 수행
@@ -25,6 +32,7 @@ jobs:
   release:
     if: |
       github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'push' ||
       (
         github.event.workflow_run.event == 'push' &&
         github.event.workflow_run.conclusion == 'success' &&
@@ -40,28 +48,46 @@ jobs:
 
       - uses: azure/setup-helm@v4
 
-      # 어떤 워크플로가 끝났는지에 따라 대상 서비스 결정 (user/spot)
-      - name: Detect built service
+      # 대상 서비스 감지: workflow_run이면 이름으로, 그 외면 inputs 또는 both
+      - name: Resolve target services
         id: svc
+        shell: bash
         run: |
-          N="${{ github.event.workflow_run.name }}"
-          if echo "$N" | grep -qi "User Service"; then
-            echo "name=user-service"   >> $GITHUB_OUTPUT
-            echo "chart_dir=charts/user-service" >> $GITHUB_OUTPUT
-            echo "pipeline_id=contest11-dev-pipeline-1" >> $GITHUB_OUTPUT
-          elif echo "$N" | grep -qi "Spot Service"; then
-            echo "name=spot-service"   >> $GITHUB_OUTPUT
-            echo "chart_dir=charts/spot-service" >> $GITHUB_OUTPUT
-            echo "pipeline_id=contest11-dev-pipeline-2" >> $GITHUB_OUTPUT
+          TARGETS=""
+          if [[ "${{ github.event_name }}" == "workflow_run" ]]; then
+            N="${{ github.event.workflow_run.name }}"
+            if echo "$N" | grep -qi "User Service"; then
+              TARGETS="user-service"
+            fi
+            if echo "$N" | grep -qi "Spot Service"; then
+              TARGETS="${TARGETS:+$TARGETS,}spot-service"
+            fi
           else
-            echo "Unknown workflow: $N"; exit 1
+            # workflow_dispatch / push
+            case "${{ inputs.service }}" in
+              user-service) TARGETS="user-service" ;;
+              spot-service) TARGETS="spot-service" ;;
+              both|"")      TARGETS="user-service,spot-service" ;;
+            esac
           fi
 
-      # 커밋 없이 '로컬 파일'의 버전만 변경 (둘 중 해당 서비스만 변경)
+          # 안전장치: 비어있으면 both
+          if [[ -z "$TARGETS" ]]; then
+            TARGETS="user-service,spot-service"
+          fi
+
+          echo "targets=$TARGETS" >> "$GITHUB_OUTPUT"
+
+      # 커밋 없이 '로컬 파일'의 버전만 변경 (여러 서비스 처리)
       - name: Set chart version (no commit)
+        shell: bash
         run: |
           V="0.1.${GITHUB_RUN_NUMBER}"
-          sed -i "s/^version: .*/version: ${V}/" "${{ steps.svc.outputs.chart_dir }}/Chart.yaml"
+          IFS=, read -ra arr <<< "${{ steps.svc.outputs.targets }}"
+          for s in "${arr[@]}"; do
+            sed -i "s/^version: .*/version: ${V}/" "charts/$s/Chart.yaml"
+            echo "Bumped charts/$s/Chart.yaml to ${V}"
+          done
           echo "VERSION=${V}" >> $GITHUB_ENV
 
       # PAT로 릴리스 + gh-pages/index.yaml 갱신
@@ -80,19 +106,28 @@ jobs:
             curl -fsSL "$CHART_BASE_URL/index.yaml" | grep "${VERSION}" && break || sleep 2
           done
 
-      # NHN Pipeline Anchor: 차트 발행 이후에 트리거하여 순서 보장
-      - name: Execute NHN Pipeline (dev)
+      # NHN Pipeline Anchor: 차트 발행 이후에 트리거하여 순서 보장 (여러 서비스 처리)
+      - name: Execute NHN Pipelines (dev)
         env:
           NHN_REGION: KR1
           NHN_APPKEY: ${{ secrets.NHN_APPKEY }}
           NHN_AUTH_ID: ${{ secrets.NHN_USER_ACCESS_KEY_ID }}
           NHN_AUTH_SECRET: ${{ secrets.NHN_USER_ACCESS_KEY_SECRET }}
+        shell: bash
         run: |
           set -eux
-          curl --fail --show-error --location --max-time 30 -i -X POST \
-            -H "Content-Type:application/json" \
-            -H "X-NHN-REGION:${NHN_REGION}" \
-            -H "X-TC-AUTHENTICATION-ID:${NHN_AUTH_ID}" \
-            -H "X-TC-AUTHENTICATION-SECRET:${NHN_AUTH_SECRET}" \
-            -H "X-NHN-APPKEY:${NHN_APPKEY}" \
-            "https://kr1-pipeline.api.nhncloudservice.com/api/anchor/v1.0/pipelines/${{ steps.svc.outputs.pipeline_id }}/execute"
+          IFS=, read -ra arr <<< "${{ steps.svc.outputs.targets }}"
+          for s in "${arr[@]}"; do
+            case "$s" in
+              user-service) PID="contest11-dev-pipeline-1" ;;
+              spot-service) PID="contest11-dev-pipeline-2" ;;
+              *) echo "unknown service: $s"; exit 1 ;;
+            esac
+            curl --fail --show-error --location --max-time 30 -i -X POST \
+              -H "Content-Type:application/json" \
+              -H "X-NHN-REGION:${NHN_REGION}" \
+              -H "X-TC-AUTHENTICATION-ID:${NHN_AUTH_ID}" \
+              -H "X-TC-AUTHENTICATION-SECRET:${NHN_AUTH_SECRET}" \
+              -H "X-NHN-APPKEY:${NHN_APPKEY}" \
+              "https://kr1-pipeline.api.nhncloudservice.com/api/anchor/v1.0/pipelines/${PID}/execute"
+          done


### PR DESCRIPTION
## 요약
release-charts 워크플로를 개선하여 여러 차트를 동시에 처리하고, 수동 실행 시 릴리스할 차트를 선택하도록 개선.

<br>

## 작업 내용
- **workflow_dispatch 입력 옵션 추가**
  - service 파라미터: `user-service`, `spot-service`, `both` 중 선택 가능
  - 기본값: `both` (두 차트 모두 릴리스)

- **대상 서비스 감지 로직 개선**
  - workflow_run 이벤트: 빌드 워크플로 이름으로 서비스 자동 감지
  - workflow_dispatch/push 이벤트: 입력값 또는 기본값(both) 사용
  - 안전장치 추가: 감지 실패 시에도 both로 진행 (exit 1 제거)

- **여러 서비스 동시 처리**
  - 버전 세팅 스텝: 쉼표로 구분된 서비스 목록을 순회하며 Chart.yaml 업데이트
  - NHN Pipeline 트리거: 각 서비스에 해당하는 파이프라인 ID 매핑 후 순차 실행

- **트리거 조건 개선**
  - push 이벤트를 if 조건에 추가하여 charts/** 또는 워크플로 파일 변경 시 자동 실행
  - on 블록 구조 정리 (push가 workflow_run 내부에 잘못 위치했던 문제 수정)

<br>

## 참고 사항
- **chart-releaser 자동 스킵**: 변경되지 않은 차트는 자동으로 스킵되므로 both로 실행해도 부담이 거의 없음
- **유연한 릴리스**: 수동 실행 시 특정 서비스만 선택하여 릴리스 가능
- **안전성 향상**: 서비스 감지 실패 시에도 워크플로가 중단되지 않고 both로 진행
- **테스트 용이성**: 워크플로 파일 수정 시 develop 브랜치에 push하면 바로 테스트 가능

<br>

## 관련 이슈

<br>