### PR TITLE
Fix(charts): avoid 422 by skipping existing releases

### DIFF
--- a/.github/workflows/release-charts.yml
+++ b/.github/workflows/release-charts.yml
@@ -82,11 +82,11 @@ jobs:
       - name: Set chart version (no commit)
         shell: bash
         run: |
-          V="0.1.${GITHUB_RUN_NUMBER}"
+          V="0.1.${GITHUB_RUN_NUMBER}-${GITHUB_RUN_ATTEMPT}"  # 예: 0.1.4-2
           IFS=, read -ra arr <<< "${{ steps.svc.outputs.targets }}"
           for s in "${arr[@]}"; do
-            sed -i "s/^version: .*/version: ${V}/" "charts/$s/Chart.yaml"
-            echo "Bumped charts/$s/Chart.yaml to ${V}"
+          sed -i "s/^version: .*/version: ${V}/" "charts/$s/Chart.yaml"
+          echo "Bumped charts/$s/Chart.yaml to ${V}"
           done
           echo "VERSION=${V}" >> $GITHUB_ENV
 
@@ -95,6 +95,7 @@ jobs:
         uses: helm/chart-releaser-action@v1.7.0
         with:
           charts_dir: charts
+          skip_existing: true # 동일 태그 있으면 업로드 스킵(실패하지 않음)
         env:
           CR_TOKEN: ${{ secrets.CHARTS_PAT }}
 


### PR DESCRIPTION
## 요약
chart-releaser 422 (duplicate tag) → skip_existing

<br>

## 작업 내용
- skip_existing: true로 중복 릴리스 건너뜀
- version = 0.1.${run_number}-${run_attempt}로 유니크 버전 보장

<br>

## 참고 사항

<br>

## 관련 이슈

<br>