### PR TITLE
Fix(ci): Configure git author for chart-releaser action

### DIFF
--- a/.github/workflows/release-charts.yml
+++ b/.github/workflows/release-charts.yml
@@ -48,6 +48,12 @@ jobs:
 
       - uses: azure/setup-helm@v4
 
+      # Git author 설정 (gh-pages에 index.yaml 커밋용)
+      - name: Configure git author for gh-pages commit
+        run: |
+          git config --global user.name  "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
       # 대상 서비스 감지: workflow_run이면 이름으로, 그 외면 inputs 또는 both
       - name: Resolve target services
         id: svc


### PR DESCRIPTION
## 요약
chart-releaser-action이 gh-pages 브랜치에 index.yaml을 커밋할 때 사용할 git author를 명시적으로 설정.

<br>

## 작업 내용
- **git author 설정 스텝 추가**
  - github-actions[bot] 계정 정보로 설정
  - user.name: `github-actions[bot]`
  - user.email: `41898282+github-actions[bot]@users.noreply.github.com`

- **배치 위치**
  - Helm 설치 직후, 서비스 감지 로직 이전에 배치
  - chart-releaser-action이 실행되기 전에 git 설정 완료

<br>

## 참고 사항

<br>

## 관련 이슈

<br>