### PR TITLE
Fix(ci): use PAT for actions/checkout to fix gh-pages push 403

### DIFF
--- a/.github/workflows/release-charts.yml
+++ b/.github/workflows/release-charts.yml
@@ -45,6 +45,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.CHARTS_PAT }}
 
       - uses: azure/setup-helm@v4
 


### PR DESCRIPTION
## 요약
actions/checkout에 PAT 적

<br>

## 작업 내용
- checkout 단계에 token: ${{ secrets.CHARTS_PAT }} 추가
- chart-releaser의 index.yaml push가 github-actions[bot] 권한 부족(403)으로 실패하던 문제 해결
- GITHUB_TOKEN 권한은 contents: read 유지, push는 PAT로 처리

<br>

## 참고 사항

<br>

## 관련 이슈

<br>