### PR TITLE
Feat(auth): Add Kakao SDK login and user registration

### DIFF
--- a/src/main/java/com/gemmap/gemmap/auth/application/dto/kakao/KakaoAccessTokenInfoResponse.java
+++ b/src/main/java/com/gemmap/gemmap/auth/application/dto/kakao/KakaoAccessTokenInfoResponse.java
@@ -1,0 +1,23 @@
+package com.gemmap.gemmap.auth.application.dto.kakao;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 카카오 액세스 토큰 정보 응답 DTO
+ * GET /v1/user/access_token_info 응답
+ */
+@Getter
+@NoArgsConstructor
+public class KakaoAccessTokenInfoResponse {
+
+    @JsonProperty("app_id")
+    private Long appId;
+
+    @JsonProperty("id")
+    private Long id;
+
+    @JsonProperty("expires_in")
+    private Integer expiresIn;
+}

--- a/src/main/java/com/gemmap/gemmap/auth/application/dto/kakao/KakaoUserInfoResponse.java
+++ b/src/main/java/com/gemmap/gemmap/auth/application/dto/kakao/KakaoUserInfoResponse.java
@@ -31,6 +31,14 @@ public class KakaoUserInfoResponse {
     public static class KakaoAccount {
         private Profile profile;
         private String email;
+        private String name;
+        private String gender;
+
+        @JsonProperty("age_range")
+        private String ageRange;
+
+        private String birthday;
+        private String birthyear;
 
         @Getter
         @NoArgsConstructor

--- a/src/main/java/com/gemmap/gemmap/auth/application/dto/request/RegisterRequestDto.java
+++ b/src/main/java/com/gemmap/gemmap/auth/application/dto/request/RegisterRequestDto.java
@@ -1,0 +1,13 @@
+package com.gemmap.gemmap.auth.application.dto.request;
+
+import org.springframework.web.multipart.MultipartFile;
+
+/**
+ * 회원가입 요청 DTO
+ * 닉네임과 프로필 이미지는 선택사항
+ */
+public record RegisterRequestDto(
+        String nickname,
+        MultipartFile profileImage
+) {
+}

--- a/src/main/java/com/gemmap/gemmap/auth/application/dto/response/KakaoLoginResponseDto.java
+++ b/src/main/java/com/gemmap/gemmap/auth/application/dto/response/KakaoLoginResponseDto.java
@@ -6,12 +6,12 @@ import com.gemmap.gemmap.shared.common.enums.ERole;
  * 카카오 로그인 응답 DTO (단순화된 버전)
  */
 public record KakaoLoginResponseDto(
-        String accessToken,         // 서비스 JWT 액세스 토큰
-        String refreshToken,        // 서비스 JWT 리프레시 토큰
+        Long userId,                // 사용자 ID
         String role,                // 사용자 역할
-        Long userId                 // 사용자 ID
+        String accessToken,         // 서비스 JWT 액세스 토큰
+        String refreshToken         // 서비스 JWT 리프레시 토큰
 ) {
-    public static KakaoLoginResponseDto of(String accessToken, String refreshToken, ERole role, Long userId) {
-        return new KakaoLoginResponseDto(accessToken, refreshToken, role.toString(), userId);
+    public static KakaoLoginResponseDto of(Long userId, ERole role, String accessToken, String refreshToken) {
+        return new KakaoLoginResponseDto(userId, role.toString(), accessToken, refreshToken);
     }
 }

--- a/src/main/java/com/gemmap/gemmap/auth/application/dto/response/RegisterResponseDto.java
+++ b/src/main/java/com/gemmap/gemmap/auth/application/dto/response/RegisterResponseDto.java
@@ -1,0 +1,19 @@
+package com.gemmap.gemmap.auth.application.dto.response;
+
+/**
+ * 회원가입 완료 응답 DTO
+ * role 변경으로 인해 새로운 JWT 토큰도 함께 반환
+ */
+public record RegisterResponseDto(
+        Long userId,
+        String role,
+        String nickname,
+        String profileImage,
+        String accessToken,
+        String refreshToken
+) {
+    public static RegisterResponseDto of(Long userId, String role, String nickname, String profileImage,
+                                          String accessToken, String refreshToken) {
+        return new RegisterResponseDto(userId, role, nickname, profileImage, accessToken, refreshToken);
+    }
+}

--- a/src/main/java/com/gemmap/gemmap/auth/application/service/AuthService.java
+++ b/src/main/java/com/gemmap/gemmap/auth/application/service/AuthService.java
@@ -51,59 +51,6 @@ public class AuthService {
     private final S3UrlGenerator s3UrlGenerator;
     private final S3Properties s3Properties;
 
-    /**
-     * 카카오 인가 URL 생성
-     */
-    public String getKakaoAuthorizationUrl() {
-        try {
-            return kakaoOAuth2Service.getAuthorizationUrl();
-        } catch (Exception e) {
-            log.error("카카오 인가 URL 생성 실패: {}", e.getMessage());
-            throw new CommonException(ErrorCode.EXTERNAL_SERVICE_ERROR);
-        }
-    }
-
-    /**
-    * 카카오 로그인 처리 (인가 코드로 로그인)
-    */
-    @Transactional
-    public KakaoLoginResponseDto kakaoLogin(String authorizationCode) {
-        if (authorizationCode == null || authorizationCode.trim().isEmpty()) {
-            throw new CommonException(ErrorCode.INVALID_INPUT_VALUE);
-        }
-
-        try {
-            KakaoTokenResponse tokenResponse = kakaoOAuth2Service.getAccessToken(authorizationCode);
-            KakaoUserInfoResponse userInfo = kakaoOAuth2Service.getUserInfo(tokenResponse.getAccessToken());
-
-            if (userInfo.getId() == null) {
-                throw new CommonException(ErrorCode.EXTERNAL_SERVICE_ERROR);
-            }
-
-            String socialId = userInfo.getId().toString();
-            String email = userInfo.getKakaoAccount() != null ? userInfo.getKakaoAccount().getEmail() : null;
-            User user = findOrCreateKakaoUser(socialId, email, userInfo);
-
-            JwtTokenDto jwtTokenDto = jwtUtil.generateTokens(user.getId(), user.getRole());
-            user.updateRefreshToken(jwtTokenDto.getRefreshToken());
-            user.updateLoginStatus(true);
-
-            log.info("카카오 로그인 성공 - 사용자 ID: {}, 권한: {}", user.getId(), user.getRole());
-
-            return KakaoLoginResponseDto.of(
-                    user.getId(),
-                    user.getRole(),
-                    jwtTokenDto.getAccessToken(),
-                    jwtTokenDto.getRefreshToken()
-            );
-        } catch (CommonException e) {
-            // CommonException은 그대로 재던지기
-            throw e;
-        } catch (Exception e) {
-            log.error("카카오 로그인 처리 중 예상치 못한 오류: {}", e.getMessage(), e);
-            throw new CommonException(ErrorCode.INTERNAL_SERVER_ERROR);
-        }
-    }
 
     /**
      * 카카오 사용자 조회 또는 생성

--- a/src/main/java/com/gemmap/gemmap/auth/application/service/AuthService.java
+++ b/src/main/java/com/gemmap/gemmap/auth/application/service/AuthService.java
@@ -1,5 +1,6 @@
 package com.gemmap.gemmap.auth.application.service;
 
+import com.gemmap.gemmap.auth.application.dto.kakao.KakaoAccessTokenInfoResponse;
 import com.gemmap.gemmap.auth.application.dto.kakao.KakaoTokenResponse;
 import com.gemmap.gemmap.auth.application.dto.kakao.KakaoUserInfoResponse;
 import com.gemmap.gemmap.auth.application.dto.response.KakaoLoginResponseDto;
@@ -108,15 +109,16 @@ public class AuthService {
                 User existingUser = userOpt.get();
                 // 기존 사용자의 카카오 정보 업데이트
                 updateKakaoUserInfo(existingUser, userInfo);
-                log.info("기존 카카오 사용자 로그인 - 사용자 ID: {}", existingUser.getId());
-                return existingUser;
+                User savedUser = userRepository.save(existingUser);
+                log.info("기존 카카오 사용자 정보 업데이트 - 사용자 ID: {}", savedUser.getId());
+                return savedUser;
             }
 
             // 신규 사용자 생성
             User newUser = createKakaoUser(socialId, email, userInfo);
-            userRepository.save(newUser);
-            log.info("신규 카카오 사용자 생성 - 소셜 ID: {}", socialId);
-            return newUser;
+            User savedUser = userRepository.save(newUser);
+            log.info("신규 카카오 사용자 생성 - 소셜 ID: {}, 사용자 ID: {}", socialId, savedUser.getId());
+            return savedUser;
         } catch (Exception e) {
             log.error("카카오 사용자 처리 중 오류: {}", e.getMessage(), e);
             throw new CommonException(ErrorCode.DATABASE_ERROR);
@@ -125,17 +127,34 @@ public class AuthService {
 
     /**
      * 카카오 사용자 생성
+     * 신규 사용자는 GUEST 권한으로 생성
      */
     private User createKakaoUser(String socialId, String email, KakaoUserInfoResponse userInfo) {
         KakaoUserInfoResponse.KakaoAccount account = userInfo.getKakaoAccount();
 
+        String name = extractName(userInfo);
+        String nickname = extractNickname(userInfo);
+        String profileImage = extractProfileImage(userInfo);
+        String gender = extractGender(userInfo);
+        String ageRange = extractAgeRange(userInfo);
+        String birthday = extractBirthday(userInfo);
+        String birthyear = extractBirthyear(userInfo);
+
+        log.info("신규 카카오 사용자 생성 준비 - Email: {}, Name: {}, Nickname: {}, Gender: {}, AgeRange: {}, Birthday: {}, Birthyear: {}",
+                email, name, nickname, gender, ageRange, birthday, birthyear);
+
         return User.builder()
                 .socialId(socialId)
                 .eProvider(EProvider.KAKAO)
-                .role(ERole.USER)
+                .role(ERole.GUEST)
                 .email(email)
-                .nickname(extractNickname(userInfo))
-                .profileImage(extractProfileImage(userInfo))
+                .name(name)
+                .nickname(nickname)
+                .profileImage(profileImage)
+                .gender(gender)
+                .ageRange(ageRange)
+                .birthday(birthday)
+                .birthyear(birthyear)
                 .build();
     }
 
@@ -145,9 +164,25 @@ public class AuthService {
     private void updateKakaoUserInfo(User user, KakaoUserInfoResponse userInfo) {
         KakaoUserInfoResponse.KakaoAccount account = userInfo.getKakaoAccount();
 
+        String name = extractName(userInfo);
+        String nickname = extractNickname(userInfo);
+        String profileImage = extractProfileImage(userInfo);
+        String gender = extractGender(userInfo);
+        String ageRange = extractAgeRange(userInfo);
+        String birthday = extractBirthday(userInfo);
+        String birthyear = extractBirthyear(userInfo);
+
+        log.info("기존 카카오 사용자 정보 업데이트 준비 - UserID: {}, Name: {}, Nickname: {}, Gender: {}, AgeRange: {}, Birthday: {}, Birthyear: {}",
+                user.getId(), name, nickname, gender, ageRange, birthday, birthyear);
+
         user.updateKakaoUserInfo(
-                extractNickname(userInfo),
-                extractProfileImage(userInfo)
+                name,
+                nickname,
+                profileImage,
+                gender,
+                ageRange,
+                birthday,
+                birthyear
         );
     }
 
@@ -196,6 +231,71 @@ public class AuthService {
                 profile -> profile.getProfileImageUrl(),
                 properties -> properties.getProfileImage(),
                 Constant.DEFAULT_PROFILE_IMAGE);
+    }
+
+    /**
+     * 이름 추출 (kakao_account.name)
+     */
+    private String extractName(KakaoUserInfoResponse userInfo) {
+        if (userInfo.getKakaoAccount() != null) {
+            String name = userInfo.getKakaoAccount().getName();
+            log.debug("카카오 사용자 이름 추출: {}", name);
+            return name;
+        }
+        log.debug("카카오 계정 정보 없음 - 이름 추출 실패");
+        return null;
+    }
+
+    /**
+     * 성별 추출 (kakao_account.gender)
+     */
+    private String extractGender(KakaoUserInfoResponse userInfo) {
+        if (userInfo.getKakaoAccount() != null) {
+            String gender = userInfo.getKakaoAccount().getGender();
+            log.debug("카카오 사용자 성별 추출: {}", gender);
+            return gender;
+        }
+        log.debug("카카오 계정 정보 없음 - 성별 추출 실패");
+        return null;
+    }
+
+    /**
+     * 연령대 추출 (kakao_account.age_range)
+     */
+    private String extractAgeRange(KakaoUserInfoResponse userInfo) {
+        if (userInfo.getKakaoAccount() != null) {
+            String ageRange = userInfo.getKakaoAccount().getAgeRange();
+            log.debug("카카오 사용자 연령대 추출: {}", ageRange);
+            return ageRange;
+        }
+        log.debug("카카오 계정 정보 없음 - 연령대 추출 실패");
+        return null;
+    }
+
+    /**
+     * 생일 추출 (kakao_account.birthday)
+     */
+    private String extractBirthday(KakaoUserInfoResponse userInfo) {
+        if (userInfo.getKakaoAccount() != null) {
+            String birthday = userInfo.getKakaoAccount().getBirthday();
+            log.debug("카카오 사용자 생일 추출: {}", birthday);
+            return birthday;
+        }
+        log.debug("카카오 계정 정보 없음 - 생일 추출 실패");
+        return null;
+    }
+
+    /**
+     * 출생연도 추출 (kakao_account.birthyear)
+     */
+    private String extractBirthyear(KakaoUserInfoResponse userInfo) {
+        if (userInfo.getKakaoAccount() != null) {
+            String birthyear = userInfo.getKakaoAccount().getBirthyear();
+            log.debug("카카오 사용자 출생연도 추출: {}", birthyear);
+            return birthyear;
+        }
+        log.debug("카카오 계정 정보 없음 - 출생연도 추출 실패");
+        return null;
     }
 
 
@@ -334,6 +434,55 @@ public class AuthService {
             throw e;
         } catch (Exception e) {
             log.error("로그아웃 처리 중 예상치 못한 오류: {}", e.getMessage(), e);
+            throw new CommonException(ErrorCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    /**
+     * 카카오 Access Token으로 인증 (모바일 SDK 방식 - B안)
+     * 모바일 앱에서 획득한 카카오 Access Token을 검증하고 서비스 JWT 발급
+     */
+    @Transactional
+    public KakaoLoginResponseDto authenticateWithKakaoAccessToken(String kakaoAccessToken) {
+        if (kakaoAccessToken == null || kakaoAccessToken.trim().isEmpty()) {
+            throw new CommonException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+
+        try {
+            // 1. 카카오 Access Token 검증 (app_id 확인 및 만료 검증)
+            KakaoAccessTokenInfoResponse tokenInfo = kakaoOAuth2Service.getAccessTokenInfo(kakaoAccessToken);
+
+            if (tokenInfo.getId() == null) {
+                throw new CommonException(ErrorCode.EXTERNAL_SERVICE_ERROR);
+            }
+
+            // 2. 카카오 사용자 정보 조회
+            KakaoUserInfoResponse userInfo = kakaoOAuth2Service.getUserInfo(kakaoAccessToken);
+
+            String socialId = tokenInfo.getId().toString();
+            String email = userInfo.getKakaoAccount() != null ? userInfo.getKakaoAccount().getEmail() : null;
+
+            // 3. 사용자 조회 또는 생성
+            User user = findOrCreateKakaoUser(socialId, email, userInfo);
+
+            // 4. 서비스 JWT 토큰 발급
+            JwtTokenDto jwtTokenDto = jwtUtil.generateTokens(user.getId(), user.getRole());
+            user.updateRefreshToken(jwtTokenDto.getRefreshToken());
+            user.updateLoginStatus(true);
+
+            log.info("카카오 SDK 로그인 성공 - 사용자 ID: {}, 권한: {}", user.getId(), user.getRole());
+
+            return KakaoLoginResponseDto.of(
+                    jwtTokenDto.getAccessToken(),
+                    jwtTokenDto.getRefreshToken(),
+                    user.getRole(),
+                    user.getId()
+            );
+        } catch (CommonException e) {
+            // CommonException은 그대로 재던지기
+            throw e;
+        } catch (Exception e) {
+            log.error("카카오 SDK 로그인 처리 중 예상치 못한 오류: {}", e.getMessage(), e);
             throw new CommonException(ErrorCode.INTERNAL_SERVER_ERROR);
         }
     }

--- a/src/main/java/com/gemmap/gemmap/auth/application/service/AuthService.java
+++ b/src/main/java/com/gemmap/gemmap/auth/application/service/AuthService.java
@@ -5,22 +5,30 @@ import com.gemmap.gemmap.auth.application.dto.kakao.KakaoTokenResponse;
 import com.gemmap.gemmap.auth.application.dto.kakao.KakaoUserInfoResponse;
 import com.gemmap.gemmap.auth.application.dto.response.KakaoLoginResponseDto;
 import com.gemmap.gemmap.auth.application.dto.response.KakaoTokenRefreshResponseDto;
+import com.gemmap.gemmap.auth.application.dto.response.RegisterResponseDto;
 import com.gemmap.gemmap.auth.domain.entity.User;
 import com.gemmap.gemmap.auth.domain.repository.UserRepository;
 import com.gemmap.gemmap.auth.infrastructure.jwt.JwtTokenDto;
 import com.gemmap.gemmap.auth.infrastructure.jwt.JwtUtil;
 import com.gemmap.gemmap.auth.infrastructure.oauth.KakaoOAuth2Service;
+import com.gemmap.gemmap.image.infrastructure.objectstorage.ObjectStorageService;
+import com.gemmap.gemmap.image.infrastructure.objectstorage.S3UrlGenerator;
 import com.gemmap.gemmap.shared.common.constants.Constant;
 import com.gemmap.gemmap.shared.common.enums.EProvider;
 import com.gemmap.gemmap.shared.common.enums.ERole;
+import com.gemmap.gemmap.shared.config.s3.S3Properties;
 import com.gemmap.gemmap.shared.exception.CommonException;
 import com.gemmap.gemmap.shared.exception.ErrorCode;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.Optional;
+import java.util.UUID;
 
 /**
  * 인증 관련 비즈니스 로직을 처리하는 서비스 클래스
@@ -39,6 +47,9 @@ public class AuthService {
     private final UserRepository userRepository;
     private final JwtUtil jwtUtil;
     private final KakaoOAuth2Service kakaoOAuth2Service;
+    private final ObjectStorageService objectStorageService;
+    private final S3UrlGenerator s3UrlGenerator;
+    private final S3Properties s3Properties;
 
     /**
      * 카카오 인가 URL 생성
@@ -80,10 +91,10 @@ public class AuthService {
             log.info("카카오 로그인 성공 - 사용자 ID: {}, 권한: {}", user.getId(), user.getRole());
 
             return KakaoLoginResponseDto.of(
-                    jwtTokenDto.getAccessToken(),
-                    jwtTokenDto.getRefreshToken(),
+                    user.getId(),
                     user.getRole(),
-                    user.getId()
+                    jwtTokenDto.getAccessToken(),
+                    jwtTokenDto.getRefreshToken()
             );
         } catch (CommonException e) {
             // CommonException은 그대로 재던지기
@@ -403,10 +414,10 @@ public class AuthService {
                     user.getId(), shouldRotateRefreshToken);
 
             return KakaoLoginResponseDto.of(
-                    newAccessToken,
-                    newRefreshToken,
+                    user.getId(),
                     user.getRole(),
-                    user.getId()
+                    newAccessToken,
+                    newRefreshToken
             );
 
         } catch (CommonException e) {
@@ -473,10 +484,10 @@ public class AuthService {
             log.info("카카오 SDK 로그인 성공 - 사용자 ID: {}, 권한: {}", user.getId(), user.getRole());
 
             return KakaoLoginResponseDto.of(
-                    jwtTokenDto.getAccessToken(),
-                    jwtTokenDto.getRefreshToken(),
+                    user.getId(),
                     user.getRole(),
-                    user.getId()
+                    jwtTokenDto.getAccessToken(),
+                    jwtTokenDto.getRefreshToken()
             );
         } catch (CommonException e) {
             // CommonException은 그대로 재던지기
@@ -485,5 +496,126 @@ public class AuthService {
             log.error("카카오 SDK 로그인 처리 중 예상치 못한 오류: {}", e.getMessage(), e);
             throw new CommonException(ErrorCode.INTERNAL_SERVER_ERROR);
         }
+    }
+
+    /**
+     * 회원가입 처리 (GUEST → USER 권한 전환)
+     * 닉네임과 프로필 이미지를 업데이트하고 권한을 USER로 변경
+     */
+    @Transactional
+    public RegisterResponseDto register(Long userId, String nickname, MultipartFile profileImage) {
+        try {
+            // 1. 사용자 조회
+            User user = userRepository.findById(userId)
+                    .orElseThrow(() -> new CommonException(ErrorCode.USER_NOT_FOUND));
+
+            // 2. 이미 USER 권한인지 확인
+            if (user.getRole() == ERole.USER) {
+                throw new CommonException(ErrorCode.ALREADY_REGISTERED_USER);
+            }
+
+            // 3. 닉네임 처리 (입력하지 않은 경우 카카오 닉네임 유지)
+            String finalNickname = (nickname != null && !nickname.trim().isEmpty())
+                    ? nickname
+                    : user.getNickname();
+
+            // 4. 프로필 이미지 처리
+            String finalProfileImage = user.getProfileImage();
+            if (profileImage != null && !profileImage.isEmpty()) {
+                // 프로필 이미지 업로드
+                finalProfileImage = uploadProfileImage(profileImage);
+            }
+            // 입력하지 않은 경우 카카오 프로필 이미지 유지
+
+            // 5. 사용자 정보 업데이트
+            user.updateNickname(finalNickname);
+            user.updateProfileImage(finalProfileImage);
+            user.updateRole(ERole.USER);
+
+            User savedUser = userRepository.save(user);
+
+            // 6. role 변경으로 인한 새로운 JWT 토큰 발급
+            JwtTokenDto jwtTokenDto = jwtUtil.generateTokens(savedUser.getId(), savedUser.getRole());
+            savedUser.updateRefreshToken(jwtTokenDto.getRefreshToken());
+            userRepository.save(savedUser);
+
+            log.info("회원가입 완료 - 사용자 ID: {}, 닉네임: {}, 권한: {}, 새 토큰 발급",
+                    savedUser.getId(), savedUser.getNickname(), savedUser.getRole());
+
+            return RegisterResponseDto.of(
+                    savedUser.getId(),
+                    savedUser.getRole().toString(),
+                    savedUser.getNickname(),
+                    savedUser.getProfileImage(),
+                    jwtTokenDto.getAccessToken(),
+                    jwtTokenDto.getRefreshToken()
+            );
+
+        } catch (CommonException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("회원가입 처리 중 예상치 못한 오류: {}", e.getMessage(), e);
+            throw new CommonException(ErrorCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    /**
+     * 프로필 이미지 업로드
+     */
+    private String uploadProfileImage(MultipartFile file) {
+        // 이미지 파일 검증
+        validateProfileImage(file);
+
+        // 파일 키 생성 (profiles/{yyyy}/{MM}/{uuid}.{ext})
+        String key = generateProfileImageKey(file.getOriginalFilename());
+
+        // Object Storage에 업로드
+        objectStorageService.upload(s3Properties.getBucket(), key, file);
+
+        // URL 생성 및 반환
+        String fileUrl = s3UrlGenerator.generateUrl(key);
+        log.info("프로필 이미지 업로드 완료 - URL: {}", fileUrl);
+
+        return fileUrl;
+    }
+
+    /**
+     * 프로필 이미지 파일 검증
+     */
+    private void validateProfileImage(MultipartFile file) {
+        if (file == null || file.isEmpty()) {
+            throw new CommonException(ErrorCode.INVALID_INPUT_VALUE, "파일이 비어있습니다.");
+        }
+
+        // MIME 타입 검증
+        String contentType = file.getContentType();
+        if (contentType == null || !contentType.startsWith("image/")) {
+            throw new CommonException(ErrorCode.INVALID_FILE_FORMAT,
+                    "이미지 파일만 업로드할 수 있습니다.");
+        }
+
+        // 파일 크기 검증 (5MB)
+        long maxSize = 5 * 1024 * 1024;
+        if (file.getSize() > maxSize) {
+            throw new CommonException(ErrorCode.FILE_SIZE_EXCEEDED,
+                    "프로필 이미지는 5MB를 초과할 수 없습니다.");
+        }
+    }
+
+    /**
+     * 프로필 이미지 키 생성
+     */
+    private String generateProfileImageKey(String originalFilename) {
+        String extension = "";
+        if (originalFilename != null && originalFilename.contains(".")) {
+            extension = originalFilename.substring(originalFilename.lastIndexOf("."));
+        }
+
+        LocalDate now = LocalDate.now();
+        String datePath = now.format(DateTimeFormatter.ofPattern("yyyy/MM"));
+        String uuid = UUID.randomUUID().toString();
+
+        // 키 규칙: profiles/{yyyy}/{MM}/{uuid}.{ext}
+        return "profiles/" + datePath + "/" + uuid + extension;
     }
 }

--- a/src/main/java/com/gemmap/gemmap/auth/domain/entity/User.java
+++ b/src/main/java/com/gemmap/gemmap/auth/domain/entity/User.java
@@ -65,15 +65,31 @@ public class User {
     @Column(name = "email")
     private String email;
 
+    @Column(name = "name")
+    private String name;
+
     @Column(name = "nickname", unique = true)
     private String nickname;
 
     @Column(name = "profile_image")
     private String profileImage;
 
+    @Column(name = "gender")
+    private String gender;
+
+    @Column(name = "age_range")
+    private String ageRange;
+
+    @Column(name = "birthday")
+    private String birthday;
+
+    @Column(name = "birthyear")
+    private String birthyear;
+
     @Builder
-    public User(String socialId, EProvider eProvider, ERole role, String email,
-                String nickname, String profileImage) {
+    public User(String socialId, EProvider eProvider, ERole role, String email, String name,
+                String nickname, String profileImage, String gender, String ageRange,
+                String birthday, String birthyear) {
         this.socialId = socialId;
         this.eProvider = eProvider;
         this.role = role;
@@ -81,8 +97,13 @@ public class User {
         this.isLogin = false;
         this.isDeleted = false;
         this.email = email;
+        this.name = name;
         this.nickname = nickname;
         this.profileImage = profileImage != null ? profileImage : Constant.DEFAULT_PROFILE_IMAGE;
+        this.gender = gender;
+        this.ageRange = ageRange;
+        this.birthday = birthday;
+        this.birthyear = birthyear;
     }
 
     public void updateNickname(String nickname) {
@@ -111,9 +132,15 @@ public class User {
         this.profileImage = profileImage;
     }
 
-    public void updateKakaoUserInfo(String nickname, String profileImage) {
+    public void updateKakaoUserInfo(String name, String nickname, String profileImage,
+                                    String gender, String ageRange, String birthday, String birthyear) {
+        if (name != null) this.name = name;
         if (nickname != null) this.nickname = nickname;
         if (profileImage != null) this.profileImage = profileImage;
+        if (gender != null) this.gender = gender;
+        if (ageRange != null) this.ageRange = ageRange;
+        if (birthday != null) this.birthday = birthday;
+        if (birthyear != null) this.birthyear = birthyear;
     }
 
     /**

--- a/src/main/java/com/gemmap/gemmap/auth/infrastructure/oauth/KakaoOAuth2Service.java
+++ b/src/main/java/com/gemmap/gemmap/auth/infrastructure/oauth/KakaoOAuth2Service.java
@@ -1,5 +1,6 @@
 package com.gemmap.gemmap.auth.infrastructure.oauth;
 
+import com.gemmap.gemmap.auth.application.dto.kakao.KakaoAccessTokenInfoResponse;
 import com.gemmap.gemmap.auth.application.dto.kakao.KakaoTokenResponse;
 import com.gemmap.gemmap.auth.application.dto.kakao.KakaoUserInfoResponse;
 import com.gemmap.gemmap.shared.exception.CommonException;
@@ -33,14 +34,18 @@ public class KakaoOAuth2Service {
     @Value("${oauth2.kakao.redirect-uri}")
     private String redirectUri;
 
+    @Value("${oauth2.kakao.app-id}")
+    private Long appId;
+
     private static final String KAUTH_HOST = "https://kauth.kakao.com";
     private static final String KAPI_HOST = "https://kapi.kakao.com";
     private static final String TOKEN_ENDPOINT = "/oauth/token";
     private static final String USER_INFO_ENDPOINT = "/v2/user/me";
+    private static final String ACCESS_TOKEN_INFO_ENDPOINT = "/v1/user/access_token_info";
     private static final String LOGOUT_ENDPOINT = "/v1/user/logout";
     private static final String AUTHORIZE_ENDPOINT = "/oauth/authorize";
     private static final String DEFAULT_SCOPE = "profile_nickname profile_image account_email name gender age_range birthday birthyear";
-    private static final String PROPERTY_KEYS = "[\"kakao_account.profile\", \"kakao_account.email\"]";
+    private static final String PROPERTY_KEYS = "[\"kakao_account.profile\", \"kakao_account.email\", \"kakao_account.name\", \"kakao_account.gender\", \"kakao_account.age_range\", \"kakao_account.birthday\", \"kakao_account.birthyear\"]";
 
     /**
      * 카카오 인가 코드 요청 URL 생성
@@ -112,6 +117,8 @@ public class KakaoOAuth2Service {
 
         HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(params, headers);
 
+        log.debug("카카오 사용자 정보 요청 - property_keys: {}", PROPERTY_KEYS);
+
         try {
             ResponseEntity<KakaoUserInfoResponse> response = restTemplate.exchange(
                     KAPI_HOST + USER_INFO_ENDPOINT,
@@ -121,7 +128,17 @@ public class KakaoOAuth2Service {
             );
 
             if (response.getStatusCode() == HttpStatus.OK && response.getBody() != null) {
-                return response.getBody();
+                KakaoUserInfoResponse userInfo = response.getBody();
+                log.debug("카카오 사용자 정보 응답 - ID: {}, Email: {}, Name: {}, Gender: {}, AgeRange: {}, Birthday: {}, Birthyear: {}",
+                        userInfo.getId(),
+                        userInfo.getKakaoAccount() != null ? userInfo.getKakaoAccount().getEmail() : null,
+                        userInfo.getKakaoAccount() != null ? userInfo.getKakaoAccount().getName() : null,
+                        userInfo.getKakaoAccount() != null ? userInfo.getKakaoAccount().getGender() : null,
+                        userInfo.getKakaoAccount() != null ? userInfo.getKakaoAccount().getAgeRange() : null,
+                        userInfo.getKakaoAccount() != null ? userInfo.getKakaoAccount().getBirthday() : null,
+                        userInfo.getKakaoAccount() != null ? userInfo.getKakaoAccount().getBirthyear() : null
+                );
+                return userInfo;
             }
 
             log.error("카카오 사용자 정보 조회 실패: {}", response.getStatusCode());
@@ -130,6 +147,47 @@ public class KakaoOAuth2Service {
         } catch (Exception e) {
             log.error("카카오 사용자 정보 조회 중 오류 발생: {}", e.getMessage(), e);
             throw new CommonException(ErrorCode.KAKAO_USER_INFO_REQUEST_FAILED);
+        }
+    }
+
+    /**
+     * Access Token 정보 조회 및 검증
+     * 모바일 SDK 방식에서 사용
+     */
+    public KakaoAccessTokenInfoResponse getAccessTokenInfo(String accessToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(accessToken);
+
+        HttpEntity<String> request = new HttpEntity<>(headers);
+
+        try {
+            ResponseEntity<KakaoAccessTokenInfoResponse> response = restTemplate.exchange(
+                    KAPI_HOST + ACCESS_TOKEN_INFO_ENDPOINT,
+                    HttpMethod.GET,
+                    request,
+                    KakaoAccessTokenInfoResponse.class
+            );
+
+            if (response.getStatusCode() == HttpStatus.OK && response.getBody() != null) {
+                KakaoAccessTokenInfoResponse tokenInfo = response.getBody();
+
+                // app_id 검증
+                if (!tokenInfo.getAppId().equals(appId)) {
+                    log.error("카카오 앱 ID 불일치 - 예상: {}, 실제: {}", appId, tokenInfo.getAppId());
+                    throw new CommonException(ErrorCode.INVALID_TOKEN);
+                }
+
+                return tokenInfo;
+            }
+
+            log.error("카카오 액세스 토큰 정보 조회 실패: {}", response.getStatusCode());
+            throw new CommonException(ErrorCode.KAKAO_TOKEN_REQUEST_FAILED);
+
+        } catch (CommonException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("카카오 액세스 토큰 정보 조회 중 오류 발생: {}", e.getMessage(), e);
+            throw new CommonException(ErrorCode.KAKAO_TOKEN_REQUEST_FAILED);
         }
     }
 

--- a/src/main/java/com/gemmap/gemmap/auth/presentation/AuthController.java
+++ b/src/main/java/com/gemmap/gemmap/auth/presentation/AuthController.java
@@ -3,7 +3,12 @@ package com.gemmap.gemmap.auth.presentation;
 import com.gemmap.gemmap.auth.application.dto.response.KakaoLoginResponseDto;
 import com.gemmap.gemmap.auth.application.service.AuthService;
 import com.gemmap.gemmap.shared.common.annotation.UserId;
+import com.gemmap.gemmap.shared.common.constants.Constant;
 import com.gemmap.gemmap.shared.common.dto.ResponseDto;
+import com.gemmap.gemmap.shared.exception.CommonException;
+import com.gemmap.gemmap.shared.exception.ErrorCode;
+import com.gemmap.gemmap.shared.util.HeaderUtil;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
@@ -41,6 +46,23 @@ public class AuthController {
             @RequestParam(value = "state", required = false) String state) {
         KakaoLoginResponseDto loginResponse = authService.kakaoLogin(code);
         log.info("카카오 로그인 성공 - 사용자 ID: {}", loginResponse.userId());
+        return ResponseDto.ok(loginResponse);
+    }
+
+    /**
+     * 카카오 로그인 (모바일 SDK 방식)
+     * 모바일 앱에서 획득한 카카오 Access Token으로 인증
+     */
+    @PostMapping("/kakao/login")
+    public ResponseDto<KakaoLoginResponseDto> kakaoSdkLogin(HttpServletRequest request) {
+        log.info("카카오 SDK 로그인 요청");
+
+        // Authorization 헤더에서 카카오 Access Token 추출
+        String kakaoAccessToken = HeaderUtil.refineHeader(request, Constant.AUTHORIZATION_HEADER, Constant.BEARER_PREFIX)
+                .orElseThrow(() -> new CommonException(ErrorCode.INVALID_TOKEN));
+
+        KakaoLoginResponseDto loginResponse = authService.authenticateWithKakaoAccessToken(kakaoAccessToken);
+        log.info("카카오 SDK 로그인 성공 - 사용자 ID: {}", loginResponse.userId());
         return ResponseDto.ok(loginResponse);
     }
 

--- a/src/main/java/com/gemmap/gemmap/auth/presentation/AuthController.java
+++ b/src/main/java/com/gemmap/gemmap/auth/presentation/AuthController.java
@@ -29,29 +29,6 @@ public class AuthController {
     private final AuthService authService;
 
     /**
-     * 카카오 로그인 시작 (리다이렉트 방식)
-     */
-    @PostMapping("/login/kakao")
-    public void startKakaoLogin(HttpServletResponse response) throws IOException {
-        log.info("카카오 로그인 시작 요청");
-        String authUrl = authService.getKakaoAuthorizationUrl();
-        // 카카오 로그인 페이지로 리다이렉트
-        response.sendRedirect(authUrl);
-    }
-
-    /**
-     * 카카오 로그인 콜백 처리 (브라우저 리다이렉트)
-     */
-    @GetMapping("/kakao/callback")
-    public ResponseDto<KakaoLoginResponseDto> kakaoCallback(
-            @RequestParam("code") String code,
-            @RequestParam(value = "state", required = false) String state) {
-        KakaoLoginResponseDto loginResponse = authService.kakaoLogin(code);
-        log.info("카카오 로그인 성공 - 사용자 ID: {}", loginResponse.userId());
-        return ResponseDto.ok(loginResponse);
-    }
-
-    /**
      * 카카오 로그인 (모바일 SDK 방식)
      * 모바일 앱에서 획득한 카카오 Access Token으로 인증
      */

--- a/src/main/java/com/gemmap/gemmap/auth/presentation/AuthController.java
+++ b/src/main/java/com/gemmap/gemmap/auth/presentation/AuthController.java
@@ -1,6 +1,7 @@
 package com.gemmap.gemmap.auth.presentation;
 
 import com.gemmap.gemmap.auth.application.dto.response.KakaoLoginResponseDto;
+import com.gemmap.gemmap.auth.application.dto.response.RegisterResponseDto;
 import com.gemmap.gemmap.auth.application.service.AuthService;
 import com.gemmap.gemmap.shared.common.annotation.UserId;
 import com.gemmap.gemmap.shared.common.constants.Constant;
@@ -14,6 +15,7 @@ import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 /**
  * 인증 관련 REST API 컨트롤러
@@ -86,5 +88,21 @@ public class AuthController {
         log.info("서비스 로그아웃 요청 - 사용자 ID: {}", userId);
         authService.simpleLogout(userId);
         return ResponseDto.noContent();
+    }
+
+    /**
+     * 회원가입 (GUEST → USER 권한 전환)
+     * 닉네임과 프로필 이미지를 업데이트하고 권한을 USER로 변경
+     */
+    @PostMapping("/register")
+    public ResponseDto<RegisterResponseDto> register(
+            @UserId Long userId,
+            @RequestParam(value = "nickname", required = false) String nickname,
+            @RequestParam(value = "profileImage", required = false) MultipartFile profileImage) {
+        log.info("회원가입 요청 - 사용자 ID: {}, 닉네임 입력 여부: {}, 프로필 이미지 업로드 여부: {}",
+                userId, nickname != null, profileImage != null && !profileImage.isEmpty());
+
+        RegisterResponseDto response = authService.register(userId, nickname, profileImage);
+        return ResponseDto.ok(response);
     }
 }

--- a/src/main/java/com/gemmap/gemmap/shared/common/constants/Constant.java
+++ b/src/main/java/com/gemmap/gemmap/shared/common/constants/Constant.java
@@ -23,6 +23,7 @@ public class Constant {
     public static final String[] NO_NEED_AUTH_URLS = {
             "/api/v1/auth/login/kakao",
             "/api/v1/auth/kakao/callback",
+            "/api/v1/auth/kakao/login",
             "/api/v1/auth/register",
             "/api/v1/test",
             "/swagger-ui.html",

--- a/src/main/java/com/gemmap/gemmap/shared/common/constants/Constant.java
+++ b/src/main/java/com/gemmap/gemmap/shared/common/constants/Constant.java
@@ -24,7 +24,7 @@ public class Constant {
             "/api/v1/auth/login/kakao",
             "/api/v1/auth/kakao/callback",
             "/api/v1/auth/kakao/login",
-            "/api/v1/auth/register",
+//            "/api/v1/auth/register",
             "/api/v1/test",
             "/swagger-ui.html",
             "/swagger-ui/**",

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -30,6 +30,7 @@ oauth2:
     client-id: "test-kakao-client-id"
     client-secret: "test-kakao-client-secret"
     redirect-uri: "http://localhost:8080/api/v1/auth/kakao/callback"
+    app-id: 1234567890
 
 # S3 설정 (테스트용)
 s3:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -35,6 +35,7 @@ oauth2:
     client-id: ${KAKAO_CLIENT_ID}
     client-secret: ${KAKAO_CLIENT_SECRET}
     redirect-uri: ${KAKAO_REDIRECT_URI}
+    app-id: ${KAKAO_APP_ID}
 
 # NHN Cloud Object Storage 설정
 s3:


### PR DESCRIPTION
## 요약
1. 모바일 SDK 방식 카카오 로그인 구현
2. 사용자 추가 정보(이름, 성별, 연령대, 생일, 출생연도) 저장
3. 회원가입 API 구현 (GUEST → USER 권한 전환)
4. 웹 리다이렉트 방식 제거 (SDK 방식으로 통일)

<br>

## 작업 내용
- 카카오 SDK 로그인 지원 (모바일 앱)
  - **POST /api/v1/auth/kakao/login**
  - Authorization 헤더로 카카오 Access Token 전달
  - 카카오 `/v1/user/access_token_info` API로 토큰 검증
  - app_id 매칭 및 만료 시간 확인
 
- 카카오 사용자 추가 정보 저장
  - name, gender, age_range, birthday, bithyear

- 신규 사용자 권한 정책
  - 최초 로그인 시 `role=GUEST`로 생성
  - 회원가입 완료 후 `role=USER`로 변경

- 회원가입 API 구현
  - **POST /api/v1/auth/register**

- 웹 리다이렉트 방식 제거 (삭제된 엔드포인트)
  - POST /api/v1/auth/login/kakao (인가 URL 생성)
  - GET /api/v1/auth/kakao/callback (콜백 처리)

<br>

## 참고 사항

<br>

## 관련 이슈

<br>