### PR TITLE
Feat(auth): Add Kakao Logout and Refactor Authentication Logic

### DIFF
--- a/src/main/java/com/gemmap/gemmap/auth/application/service/AuthService.java
+++ b/src/main/java/com/gemmap/gemmap/auth/application/service/AuthService.java
@@ -456,32 +456,36 @@ public class AuthService {
             User user = userRepository.findById(userId)
                     .orElseThrow(() -> new CommonException(ErrorCode.USER_NOT_FOUND));
 
-            // 2. 이미 USER 권한인지 확인
+            // 2. 사용자 로그인 상태 확인
+            if (!user.isLogin()) {
+                throw new CommonException(ErrorCode.USER_NOT_LOGGED_IN);
+            }
+
+            // 3. 이미 USER 권한인지 확인
             if (user.getRole() == ERole.USER) {
                 throw new CommonException(ErrorCode.ALREADY_REGISTERED_USER);
             }
 
-            // 3. 닉네임 처리 (입력하지 않은 경우 카카오 닉네임 유지)
+            // 4. 닉네임 처리 (입력하지 않은 경우 카카오 닉네임 유지)
             String finalNickname = (nickname != null && !nickname.trim().isEmpty())
                     ? nickname
                     : user.getNickname();
 
-            // 4. 프로필 이미지 처리
+            // 5. 프로필 이미지 처리 (입력하지 않은 경우 카카오 프로필 이미지 유지)
             String finalProfileImage = user.getProfileImage();
             if (profileImage != null && !profileImage.isEmpty()) {
                 // 프로필 이미지 업로드
                 finalProfileImage = uploadProfileImage(profileImage);
             }
-            // 입력하지 않은 경우 카카오 프로필 이미지 유지
 
-            // 5. 사용자 정보 업데이트
+            // 6. 사용자 정보 업데이트
             user.updateNickname(finalNickname);
             user.updateProfileImage(finalProfileImage);
             user.updateRole(ERole.USER);
 
             User savedUser = userRepository.save(user);
 
-            // 6. role 변경으로 인한 새로운 JWT 토큰 발급
+            // 7. role 변경으로 인한 새로운 JWT 토큰 발급
             JwtTokenDto jwtTokenDto = jwtUtil.generateTokens(savedUser.getId(), savedUser.getRole());
             savedUser.updateRefreshToken(jwtTokenDto.getRefreshToken());
             userRepository.save(savedUser);
@@ -537,15 +541,13 @@ public class AuthService {
         // MIME 타입 검증
         String contentType = file.getContentType();
         if (contentType == null || !contentType.startsWith("image/")) {
-            throw new CommonException(ErrorCode.INVALID_FILE_FORMAT,
-                    "이미지 파일만 업로드할 수 있습니다.");
+            throw new CommonException(ErrorCode.INVALID_FILE_FORMAT);
         }
 
         // 파일 크기 검증 (5MB)
         long maxSize = 5 * 1024 * 1024;
         if (file.getSize() > maxSize) {
-            throw new CommonException(ErrorCode.FILE_SIZE_EXCEEDED,
-                    "프로필 이미지는 5MB를 초과할 수 없습니다.");
+            throw new CommonException(ErrorCode.FILE_SIZE_EXCEEDED);
         }
     }
 

--- a/src/main/java/com/gemmap/gemmap/auth/application/service/AuthService.java
+++ b/src/main/java/com/gemmap/gemmap/auth/application/service/AuthService.java
@@ -565,4 +565,26 @@ public class AuthService {
         // 키 규칙: profiles/{yyyy}/{MM}/{uuid}.{ext}
         return "profiles/" + datePath + "/" + uuid + extension;
     }
+
+    /**
+     * 단순 서비스 로그아웃 처리
+     * 클라이언트에서 토큰을 삭제하도록 하는 단순한 응답
+     */
+    @Transactional
+    public void logout(Long userId) {
+        try {
+            // 사용자 조회
+            User user = userRepository.findById(userId)
+                    .orElseThrow(() -> new CommonException(ErrorCode.USER_NOT_FOUND));
+
+            user.logout();
+            log.info("서비스 로그아웃 - 사용자 ID: {}", userId);
+
+        } catch (CommonException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("로그아웃 처리 중 예상치 못한 오류: {}", e.getMessage(), e);
+            throw new CommonException(ErrorCode.INTERNAL_SERVER_ERROR);
+        }
+    }
 }

--- a/src/main/java/com/gemmap/gemmap/auth/application/service/AuthService.java
+++ b/src/main/java/com/gemmap/gemmap/auth/application/service/AuthService.java
@@ -51,6 +51,54 @@ public class AuthService {
     private final S3UrlGenerator s3UrlGenerator;
     private final S3Properties s3Properties;
 
+    /**
+     * 카카오 Access Token으로 인증 (모바일 SDK 방식)
+     * 모바일 앱에서 획득한 카카오 Access Token을 검증하고 서비스 JWT 발급
+     */
+    @Transactional
+    public KakaoLoginResponseDto authenticateWithKakaoAccessToken(String kakaoAccessToken) {
+        if (kakaoAccessToken == null || kakaoAccessToken.trim().isEmpty()) {
+            throw new CommonException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+
+        try {
+            // 1. 카카오 Access Token 검증 (app_id 확인 및 만료 검증)
+            KakaoAccessTokenInfoResponse tokenInfo = kakaoOAuth2Service.getAccessTokenInfo(kakaoAccessToken);
+
+            if (tokenInfo.getId() == null) {
+                throw new CommonException(ErrorCode.EXTERNAL_SERVICE_ERROR);
+            }
+
+            // 2. 카카오 사용자 정보 조회
+            KakaoUserInfoResponse userInfo = kakaoOAuth2Service.getUserInfo(kakaoAccessToken);
+
+            String socialId = tokenInfo.getId().toString();
+            String email = userInfo.getKakaoAccount() != null ? userInfo.getKakaoAccount().getEmail() : null;
+
+            // 3. 사용자 조회 또는 생성
+            User user = findOrCreateKakaoUser(socialId, email, userInfo);
+
+            // 4. 서비스 JWT 토큰 발급
+            JwtTokenDto jwtTokenDto = jwtUtil.generateTokens(user.getId(), user.getRole());
+            user.updateRefreshToken(jwtTokenDto.getRefreshToken());
+            user.updateLoginStatus(true);
+
+            log.info("카카오 SDK 로그인 성공 - 사용자 ID: {}, 권한: {}", user.getId(), user.getRole());
+
+            return KakaoLoginResponseDto.of(
+                    user.getId(),
+                    user.getRole(),
+                    jwtTokenDto.getAccessToken(),
+                    jwtTokenDto.getRefreshToken()
+            );
+        } catch (CommonException e) {
+            // CommonException은 그대로 재던지기
+            throw e;
+        } catch (Exception e) {
+            log.error("카카오 SDK 로그인 처리 중 예상치 못한 오류: {}", e.getMessage(), e);
+            throw new CommonException(ErrorCode.INTERNAL_SERVER_ERROR);
+        }
+    }
 
     /**
      * 카카오 사용자 조회 또는 생성
@@ -197,7 +245,6 @@ public class AuthService {
     private String extractName(KakaoUserInfoResponse userInfo) {
         if (userInfo.getKakaoAccount() != null) {
             String name = userInfo.getKakaoAccount().getName();
-            log.debug("카카오 사용자 이름 추출: {}", name);
             return name;
         }
         log.debug("카카오 계정 정보 없음 - 이름 추출 실패");
@@ -210,7 +257,6 @@ public class AuthService {
     private String extractGender(KakaoUserInfoResponse userInfo) {
         if (userInfo.getKakaoAccount() != null) {
             String gender = userInfo.getKakaoAccount().getGender();
-            log.debug("카카오 사용자 성별 추출: {}", gender);
             return gender;
         }
         log.debug("카카오 계정 정보 없음 - 성별 추출 실패");
@@ -223,7 +269,6 @@ public class AuthService {
     private String extractAgeRange(KakaoUserInfoResponse userInfo) {
         if (userInfo.getKakaoAccount() != null) {
             String ageRange = userInfo.getKakaoAccount().getAgeRange();
-            log.debug("카카오 사용자 연령대 추출: {}", ageRange);
             return ageRange;
         }
         log.debug("카카오 계정 정보 없음 - 연령대 추출 실패");
@@ -236,7 +281,6 @@ public class AuthService {
     private String extractBirthday(KakaoUserInfoResponse userInfo) {
         if (userInfo.getKakaoAccount() != null) {
             String birthday = userInfo.getKakaoAccount().getBirthday();
-            log.debug("카카오 사용자 생일 추출: {}", birthday);
             return birthday;
         }
         log.debug("카카오 계정 정보 없음 - 생일 추출 실패");
@@ -249,200 +293,10 @@ public class AuthService {
     private String extractBirthyear(KakaoUserInfoResponse userInfo) {
         if (userInfo.getKakaoAccount() != null) {
             String birthyear = userInfo.getKakaoAccount().getBirthyear();
-            log.debug("카카오 사용자 출생연도 추출: {}", birthyear);
             return birthyear;
         }
         log.debug("카카오 계정 정보 없음 - 출생연도 추출 실패");
         return null;
-    }
-
-
-    /**
-     * Access Token 갱신 (userId 기반)
-     */
-    @Transactional
-    public JwtTokenDto refreshAccessToken(Long userId) {
-        try {
-            // 사용자 조회 및 로그인 상태 확인
-            User user = userRepository.findById(userId)
-                    .orElseThrow(() -> new CommonException(ErrorCode.USER_NOT_FOUND));
-
-            // 사용자 로그인 상태 확인
-            if (!user.isLogin()) {
-                throw new CommonException(ErrorCode.USER_NOT_LOGGED_IN);
-            }
-
-            // 사용자의 Refresh Token 확인
-            String refreshToken = user.getRefreshToken();
-            if (refreshToken == null || refreshToken.trim().isEmpty()) {
-                throw new CommonException(ErrorCode.INVALID_REFRESH_TOKEN);
-            }
-
-            // Refresh Token 유효성 검증
-            if (!jwtUtil.validateToken(refreshToken)) {
-                throw new CommonException(ErrorCode.INVALID_REFRESH_TOKEN);
-            }
-
-            // Refresh Token 만료 임박 시 새로 발급 (Token Rotation)
-            boolean shouldRotateRefreshToken = jwtUtil.isTokenExpiringSoon(
-                    refreshToken,
-                    (long) (jwtUtil.getRefreshTokenExpiration() * Constant.REFRESH_TOKEN_ROTATION_THRESHOLD)
-            );
-
-            // 새 Access Token 발급
-            String newAccessToken = jwtUtil.generateAccessToken(user.getId(), user.getRole());
-
-            // Refresh Token 갱신 (Token Rotation 적용)
-            String newRefreshToken = refreshToken;
-            if (shouldRotateRefreshToken) {
-                newRefreshToken = jwtUtil.generateRefreshToken(user.getId(), user.getRole());
-                user.updateRefreshToken(newRefreshToken);
-            }
-
-            log.info("토큰 갱신 완료 - 사용자 ID: {}, Refresh Token 갱신: {}",
-                    user.getId(), shouldRotateRefreshToken);
-
-            return JwtTokenDto.builder()
-                    .accessToken(newAccessToken)
-                    .refreshToken(newRefreshToken)
-                    .build();
-
-        } catch (CommonException e) {
-            throw e;
-        } catch (Exception e) {
-            log.error("토큰 갱신 처리 중 예상치 못한 오류: {}", e.getMessage(), e);
-            throw new CommonException(ErrorCode.INTERNAL_SERVER_ERROR);
-        }
-    }
-
-    /**
-     * Access Token 갱신 (KakaoLoginResponseDto 형태로 반환)
-     */
-    @Transactional
-    public KakaoLoginResponseDto refreshAccessTokenWithUserInfo(Long userId) {
-        try {
-            // 사용자 조회 및 로그인 상태 확인
-            User user = userRepository.findById(userId)
-                    .orElseThrow(() -> new CommonException(ErrorCode.USER_NOT_FOUND));
-
-            // 사용자 로그인 상태 확인
-            if (!user.isLogin()) {
-                throw new CommonException(ErrorCode.USER_NOT_LOGGED_IN);
-            }
-
-            // 사용자의 Refresh Token 확인
-            String refreshToken = user.getRefreshToken();
-            if (refreshToken == null || refreshToken.trim().isEmpty()) {
-                throw new CommonException(ErrorCode.INVALID_REFRESH_TOKEN);
-            }
-
-            // Refresh Token 유효성 검증
-            if (!jwtUtil.validateToken(refreshToken)) {
-                throw new CommonException(ErrorCode.INVALID_REFRESH_TOKEN);
-            }
-
-            // Refresh Token 만료 임박 시 새로 발급 (Token Rotation)
-            boolean shouldRotateRefreshToken = jwtUtil.isTokenExpiringSoon(
-                    refreshToken,
-                    (long) (jwtUtil.getRefreshTokenExpiration() * Constant.REFRESH_TOKEN_ROTATION_THRESHOLD)
-            );
-
-            // 새 Access Token 발급
-            String newAccessToken = jwtUtil.generateAccessToken(user.getId(), user.getRole());
-
-            // Refresh Token 갱신 (Token Rotation 적용)
-            String newRefreshToken = refreshToken;
-            if (shouldRotateRefreshToken) {
-                newRefreshToken = jwtUtil.generateRefreshToken(user.getId(), user.getRole());
-                user.updateRefreshToken(newRefreshToken);
-            }
-
-            log.info("토큰 갱신 완료 - 사용자 ID: {}, Refresh Token 갱신: {}",
-                    user.getId(), shouldRotateRefreshToken);
-
-            return KakaoLoginResponseDto.of(
-                    user.getId(),
-                    user.getRole(),
-                    newAccessToken,
-                    newRefreshToken
-            );
-
-        } catch (CommonException e) {
-            throw e;
-        } catch (Exception e) {
-            log.error("토큰 갱신 처리 중 예상치 못한 오류: {}", e.getMessage(), e);
-            throw new CommonException(ErrorCode.INTERNAL_SERVER_ERROR);
-        }
-    }
-
-    /**
-     * 단순 서비스 로그아웃 처리
-     * 클라이언트에서 토큰을 삭제하도록 하는 단순한 응답
-     */
-    public void simpleLogout(Long userId) {
-        try {
-            // 사용자 존재 확인 (보안상 필요)
-            User user = userRepository.findById(userId)
-                    .orElseThrow(() -> new CommonException(ErrorCode.USER_NOT_FOUND));
-
-            log.info("서비스 로그아웃 - 사용자 ID: {}", userId);
-            // 실제로는 클라이언트에서 토큰을 삭제하도록 204 응답만 전송
-
-        } catch (CommonException e) {
-            throw e;
-        } catch (Exception e) {
-            log.error("로그아웃 처리 중 예상치 못한 오류: {}", e.getMessage(), e);
-            throw new CommonException(ErrorCode.INTERNAL_SERVER_ERROR);
-        }
-    }
-
-    /**
-     * 카카오 Access Token으로 인증 (모바일 SDK 방식 - B안)
-     * 모바일 앱에서 획득한 카카오 Access Token을 검증하고 서비스 JWT 발급
-     */
-    @Transactional
-    public KakaoLoginResponseDto authenticateWithKakaoAccessToken(String kakaoAccessToken) {
-        if (kakaoAccessToken == null || kakaoAccessToken.trim().isEmpty()) {
-            throw new CommonException(ErrorCode.INVALID_INPUT_VALUE);
-        }
-
-        try {
-            // 1. 카카오 Access Token 검증 (app_id 확인 및 만료 검증)
-            KakaoAccessTokenInfoResponse tokenInfo = kakaoOAuth2Service.getAccessTokenInfo(kakaoAccessToken);
-
-            if (tokenInfo.getId() == null) {
-                throw new CommonException(ErrorCode.EXTERNAL_SERVICE_ERROR);
-            }
-
-            // 2. 카카오 사용자 정보 조회
-            KakaoUserInfoResponse userInfo = kakaoOAuth2Service.getUserInfo(kakaoAccessToken);
-
-            String socialId = tokenInfo.getId().toString();
-            String email = userInfo.getKakaoAccount() != null ? userInfo.getKakaoAccount().getEmail() : null;
-
-            // 3. 사용자 조회 또는 생성
-            User user = findOrCreateKakaoUser(socialId, email, userInfo);
-
-            // 4. 서비스 JWT 토큰 발급
-            JwtTokenDto jwtTokenDto = jwtUtil.generateTokens(user.getId(), user.getRole());
-            user.updateRefreshToken(jwtTokenDto.getRefreshToken());
-            user.updateLoginStatus(true);
-
-            log.info("카카오 SDK 로그인 성공 - 사용자 ID: {}, 권한: {}", user.getId(), user.getRole());
-
-            return KakaoLoginResponseDto.of(
-                    user.getId(),
-                    user.getRole(),
-                    jwtTokenDto.getAccessToken(),
-                    jwtTokenDto.getRefreshToken()
-            );
-        } catch (CommonException e) {
-            // CommonException은 그대로 재던지기
-            throw e;
-        } catch (Exception e) {
-            log.error("카카오 SDK 로그인 처리 중 예상치 못한 오류: {}", e.getMessage(), e);
-            throw new CommonException(ErrorCode.INTERNAL_SERVER_ERROR);
-        }
     }
 
     /**
@@ -566,6 +420,60 @@ public class AuthService {
 
         // 키 규칙: profiles/{yyyy}/{MM}/{uuid}.{ext}
         return "profiles/" + datePath + "/" + uuid + extension;
+    }
+
+    /**
+     * 액세스 토큰 갱신
+     */
+    @Transactional
+    public KakaoLoginResponseDto refreshAccessToken(String refreshToken) {
+        try {
+            // Refresh Token 유효성 검증
+            if (!jwtUtil.validateToken(refreshToken)) {
+                throw new CommonException(ErrorCode.INVALID_REFRESH_TOKEN);
+            }
+
+            // 사용자 조회
+            User user = userRepository.findByRefreshToken(refreshToken)
+                    .orElseThrow(() -> new CommonException(ErrorCode.INVALID_REFRESH_TOKEN));
+
+            // 사용자 로그인 상태 확인
+            if (!user.isLogin()) {
+                throw new CommonException(ErrorCode.USER_NOT_LOGGED_IN);
+            }
+
+            // Refresh Token 만료 임박 시 새로 발급 (Token Rotation)
+            boolean shouldRotateRefreshToken = jwtUtil.isTokenExpiringSoon(
+                    refreshToken,
+                    (long) (jwtUtil.getRefreshTokenExpiration() * Constant.REFRESH_TOKEN_ROTATION_THRESHOLD)
+            );
+
+            // 새 Access Token 발급
+            String newAccessToken = jwtUtil.generateAccessToken(user.getId(), user.getRole());
+
+            // Refresh Token 갱신 (Token Rotation 적용)
+            String newRefreshToken = refreshToken;
+            if (shouldRotateRefreshToken) {
+                newRefreshToken = jwtUtil.generateRefreshToken(user.getId(), user.getRole());
+                user.updateRefreshToken(newRefreshToken);
+            }
+
+            log.info("토큰 갱신 완료 - 사용자 ID: {}, Refresh Token 갱신: {}",
+                    user.getId(), shouldRotateRefreshToken);
+
+            return KakaoLoginResponseDto.of(
+                    user.getId(),
+                    user.getRole(),
+                    newAccessToken,
+                    newRefreshToken
+            );
+
+        } catch (CommonException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("토큰 갱신 처리 중 예상치 못한 오류: {}", e.getMessage(), e);
+            throw new CommonException(ErrorCode.INTERNAL_SERVER_ERROR);
+        }
     }
 
     /**

--- a/src/main/java/com/gemmap/gemmap/auth/presentation/AuthController.java
+++ b/src/main/java/com/gemmap/gemmap/auth/presentation/AuthController.java
@@ -58,28 +58,13 @@ public class AuthController {
 
     /**
      * 서비스 로그아웃
-     * 클라이언트에서 토큰을 삭제하도록 하는 로그아웃
+     * 리프레시 토큰을 삭제하도록 하는 로그아웃
      */
     @PostMapping("/logout")
     public ResponseDto<?> logout(@UserId Long userId) {
         log.info("서비스 로그아웃 요청 - 사용자 ID: {}", userId);
-        authService.simpleLogout(userId);
+
+        authService.logout(userId);
         return ResponseDto.noContent();
-    }
-
-    /**
-     * 회원가입 (GUEST → USER 권한 전환)
-     * 닉네임과 프로필 이미지를 업데이트하고 권한을 USER로 변경
-     */
-    @PostMapping("/register")
-    public ResponseDto<RegisterResponseDto> register(
-            @UserId Long userId,
-            @RequestParam(value = "nickname", required = false) String nickname,
-            @RequestParam(value = "profileImage", required = false) MultipartFile profileImage) {
-        log.info("회원가입 요청 - 사용자 ID: {}, 닉네임 입력 여부: {}, 프로필 이미지 업로드 여부: {}",
-                userId, nickname != null, profileImage != null && !profileImage.isEmpty());
-
-        RegisterResponseDto response = authService.register(userId, nickname, profileImage);
-        return ResponseDto.ok(response);
     }
 }

--- a/src/main/java/com/gemmap/gemmap/auth/presentation/AuthController.java
+++ b/src/main/java/com/gemmap/gemmap/auth/presentation/AuthController.java
@@ -66,9 +66,14 @@ public class AuthController {
      * 서비스 JWT 액세스 토큰 갱신
      */
     @PostMapping("/refresh")
-    public ResponseDto<KakaoLoginResponseDto> refreshToken(@UserId Long userId) {
-        log.info("서비스 토큰 갱신 요청 - 사용자 ID: {}", userId);
-        KakaoLoginResponseDto loginResponse = authService.refreshAccessTokenWithUserInfo(userId);
+    public ResponseDto<KakaoLoginResponseDto> refreshToken(HttpServletRequest request) {
+        log.info("서비스 토큰 갱신 요청");
+
+        // Authorization 헤더에서 서비스 Refresh Token 추출
+        String refreshToken = HeaderUtil.refineHeader(request, Constant.AUTHORIZATION_HEADER, Constant.BEARER_PREFIX)
+                .orElseThrow(() -> new CommonException(ErrorCode.INVALID_TOKEN));
+
+        KakaoLoginResponseDto loginResponse = authService.refreshAccessToken(refreshToken);
         return ResponseDto.ok(loginResponse);
     }
 

--- a/src/main/java/com/gemmap/gemmap/auth/presentation/AuthController.java
+++ b/src/main/java/com/gemmap/gemmap/auth/presentation/AuthController.java
@@ -46,6 +46,22 @@ public class AuthController {
     }
 
     /**
+     * 회원가입 (GUEST → USER 권한 전환)
+     * 닉네임과 프로필 이미지를 업데이트하고 권한을 USER로 변경
+     */
+    @PostMapping("/register")
+    public ResponseDto<RegisterResponseDto> register(
+            @UserId Long userId,
+            @RequestParam(value = "nickname", required = false) String nickname,
+            @RequestParam(value = "profileImage", required = false) MultipartFile profileImage) {
+        log.info("회원가입 요청 - 사용자 ID: {}, 닉네임 입력 여부: {}, 프로필 이미지 업로드 여부: {}",
+                userId, nickname != null, profileImage != null && !profileImage.isEmpty());
+
+        RegisterResponseDto response = authService.register(userId, nickname, profileImage);
+        return ResponseDto.ok(response);
+    }
+
+    /**
      * 서비스 토큰 갱신
      * 서비스 JWT 액세스 토큰 갱신
      */


### PR DESCRIPTION
## 요약
카카오 로그아웃 기능을 추가하고, 기존 인증 관련 로직(회원가입, 액세스 토큰 갱신)의 위치를 변경하고 불필요한 주석을 제거.

<br>

## 작업 내용
- 로그아웃 로직 추가
- 회원가입 로직의 위치를 변경하고 관련 주석 제거
- 액세스 토큰 갱신 로직의 위치를 변경하고 관련 주석 제거

<br>

## 참고 사항
- 알아야 할 추가 맥락 (ex: 디자인 문서, 기술적 고려사항)

<br>

## 관련 이슈

<br>