### PR TITLE
Feat(spot): Add spot deletion API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,5 +67,9 @@ src/main/resources/certs
 
 nul
 
+<<<<<<< Updated upstream
 # docs
+=======
+# Document
+>>>>>>> Stashed changes
 docs

--- a/src/main/java/com/gemmap/gemmap/shared/common/advice/ResponseDtoAdvice.java
+++ b/src/main/java/com/gemmap/gemmap/shared/common/advice/ResponseDtoAdvice.java
@@ -1,43 +1,43 @@
-package com.gemmap.gemmap.shared.common.advice;
-
-import com.gemmap.gemmap.shared.common.dto.ResponseDto;
-import org.springframework.core.MethodParameter;
-import org.springframework.http.MediaType;
-import org.springframework.http.converter.HttpMessageConverter;
-import org.springframework.http.server.ServerHttpRequest;
-import org.springframework.http.server.ServerHttpResponse;
-import org.springframework.web.bind.annotation.RestControllerAdvice;
-import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
-
-/**
- * ResponseDto의 httpStatus를 실제 HTTP 응답 상태 코드로 자동 설정
- *
- * - ResponseDto를 반환하는 모든 컨트롤러에 자동 적용
- * - httpStatus 필드를 읽어서 HTTP 응답의 상태 코드로 설정
- * - 기존 컨트롤러 코드 변경 없이 전역적으로 동작
- */
-@RestControllerAdvice
-public class ResponseDtoAdvice implements ResponseBodyAdvice<ResponseDto<?>> {
-
-    @Override
-    public boolean supports(MethodParameter returnType, Class<? extends HttpMessageConverter<?>> converterType) {
-        // ResponseDto 타입을 반환하는 메서드에만 적용
-        return ResponseDto.class.isAssignableFrom(returnType.getParameterType());
-    }
-
-    @Override
-    public ResponseDto<?> beforeBodyWrite(
-            ResponseDto<?> body,
-            MethodParameter returnType,
-            MediaType selectedContentType,
-            Class<? extends HttpMessageConverter<?>> selectedConverterType,
-            ServerHttpRequest request,
-            ServerHttpResponse response
-    ) {
-        if (body != null && body.httpStatus() != null) {
-            // ResponseDto의 httpStatus를 HTTP 응답 상태 코드로 설정
-            response.setStatusCode(body.httpStatus());
-        }
-        return body;
-    }
-}
+//package com.gemmap.gemmap.shared.common.advice;
+//
+//import com.gemmap.gemmap.shared.common.dto.ResponseDto;
+//import org.springframework.core.MethodParameter;
+//import org.springframework.http.MediaType;
+//import org.springframework.http.converter.HttpMessageConverter;
+//import org.springframework.http.server.ServerHttpRequest;
+//import org.springframework.http.server.ServerHttpResponse;
+//import org.springframework.web.bind.annotation.RestControllerAdvice;
+//import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
+//
+///**
+// * ResponseDto의 httpStatus를 실제 HTTP 응답 상태 코드로 자동 설정
+// *
+// * - ResponseDto를 반환하는 모든 컨트롤러에 자동 적용
+// * - httpStatus 필드를 읽어서 HTTP 응답의 상태 코드로 설정
+// * - 기존 컨트롤러 코드 변경 없이 전역적으로 동작
+// */
+//@RestControllerAdvice
+//public class ResponseDtoAdvice implements ResponseBodyAdvice<ResponseDto<?>> {
+//
+//    @Override
+//    public boolean supports(MethodParameter returnType, Class<? extends HttpMessageConverter<?>> converterType) {
+//        // ResponseDto 타입을 반환하는 메서드에만 적용
+//        return ResponseDto.class.isAssignableFrom(returnType.getParameterType());
+//    }
+//
+//    @Override
+//    public ResponseDto<?> beforeBodyWrite(
+//            ResponseDto<?> body,
+//            MethodParameter returnType,
+//            MediaType selectedContentType,
+//            Class<? extends HttpMessageConverter<?>> selectedConverterType,
+//            ServerHttpRequest request,
+//            ServerHttpResponse response
+//    ) {
+//        if (body != null && body.httpStatus() != null) {
+//            // ResponseDto의 httpStatus를 HTTP 응답 상태 코드로 설정
+//            response.setStatusCode(body.httpStatus());
+//        }
+//        return body;
+//    }
+//}

--- a/src/main/java/com/gemmap/gemmap/spot/application/service/SpotService.java
+++ b/src/main/java/com/gemmap/gemmap/spot/application/service/SpotService.java
@@ -1,5 +1,7 @@
 package com.gemmap.gemmap.spot.application.service;
 
+import com.gemmap.gemmap.auth.domain.entity.User;
+import com.gemmap.gemmap.auth.domain.repository.UserRepository;
 import com.gemmap.gemmap.image.infrastructure.objectstorage.ObjectStorageService;
 import com.gemmap.gemmap.image.infrastructure.objectstorage.S3UrlGenerator;
 import com.gemmap.gemmap.shared.config.s3.S3Properties;
@@ -25,6 +27,7 @@ import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -34,6 +37,7 @@ import java.util.UUID;
 public class SpotService {
 
     private final SpotRepository spotRepository;
+    private final UserRepository userRepository;
     private final SpotPhotoRepository spotPhotoRepository;
     private final ObjectStorageService objectStorageService;
     private final S3UrlGenerator s3UrlGenerator;
@@ -42,11 +46,15 @@ public class SpotService {
 
     @Transactional
     public SpotCreateResponse create(Long userId, SpotCreateRequest req, MultipartFile file) {
-        // 0) 요청 검증 (빠른 실패 우선: 좌표 검증 -> 파일 검증)
+        // 1) 사용자 조회
+        userRepository.findById(userId)
+                .orElseThrow(() -> new CommonException(ErrorCode.USER_NOT_FOUND));
+
+        // 2) 요청 검증 (빠른 실패 우선: 좌표 검증 -> 파일 검증)
         validateCoordinates(req.latitude(), req.longitude());
         spotFileValidator.validateImage(file);
 
-        // 1) 업로드 (키 규칙: spots/yyyy/MM/uuid.ext)
+        // 3) 업로드 (키 규칙: spots/yyyy/MM/uuid.ext)
         String key = buildSpotKey(file.getOriginalFilename());
         String fileUrl;
         try {
@@ -60,7 +68,7 @@ public class SpotService {
         }
 
         try {
-            // 2) spots 저장
+            // 4) spots 저장
             Spot spot = spotRepository.save(
                 Spot.builder()
                     .userId(userId)
@@ -69,7 +77,7 @@ public class SpotService {
                     .build()
             );
 
-            // 3) spot_photos 저장 (type=SPOT, fileUrl 직접 저장)
+            // 5) spot_photos 저장 (type=SPOT, fileUrl 직접 저장)
             SpotPhoto photo = SpotPhoto.builder()
                 .spot(spot)
                 .fileUrl(fileUrl)
@@ -86,7 +94,7 @@ public class SpotService {
                 .build();
             spotPhotoRepository.save(photo);
 
-            // 4) 응답
+            // 6) 응답
             return SpotCreateResponse.builder()
                 .spotId(spot.getId())
                 .fileUrl(fileUrl)
@@ -133,6 +141,57 @@ public class SpotService {
             log.info("Compensated: deleted S3 object {}", key);
         } catch (Exception e) {
             log.warn("Failed to delete S3 object {} during compensation", key, e);
+        }
+    }
+
+    /**
+     * 스팟 삭제 (DB 우선 삭제 후 Object Storage 삭제)
+     *
+     * @param userId 요청 사용자 ID
+     * @param spotId 삭제할 스팟 ID
+     */
+    @Transactional
+    public void delete(Long userId, Long spotId) {
+        // 1) 사용자 조회
+        userRepository.findById(userId)
+                .orElseThrow(() -> new CommonException(ErrorCode.USER_NOT_FOUND));
+
+        // 2) Spot 존재 확인
+        Spot spot = spotRepository.findById(spotId)
+            .orElseThrow(() -> new CommonException(ErrorCode.RESOURCE_NOT_FOUND, "스팟을 찾을 수 없습니다."));
+
+        // 3) 소유권 검증
+        if (!spot.getUserId().equals(userId)) {
+            throw new CommonException(ErrorCode.ACCESS_DENIED, "해당 스팟을 삭제할 권한이 없습니다.");
+        }
+
+        // 4) 연결된 SpotPhoto 조회 (fileUrl 추출용)
+        List<SpotPhoto> photos = spotPhotoRepository.findBySpot(spot);
+        List<String> fileUrls = photos.stream()
+            .map(SpotPhoto::getFileUrl)
+            .toList();
+
+        // 5) DB 삭제 (트랜잭션 내): spot_photos → spots 순서 (cascade 없으므로 명시 삭제)
+        spotPhotoRepository.deleteAll(photos);
+        spotRepository.delete(spot);
+
+        // 6) Object Storage 삭제 (트랜잭션 외부, 베스트 에포트)
+        for (String fileUrl : fileUrls) {
+            safeDeleteObjectByUrl(fileUrl);
+        }
+    }
+
+    /**
+     * Object Storage 파일 삭제 (베스트 에포트, 실패 시 로그만)
+     */
+    private void safeDeleteObjectByUrl(String fileUrl) {
+        try {
+            String key = s3UrlGenerator.extractKeyFromUrl(fileUrl);
+            objectStorageService.delete(s3Properties.getBucket(), key);
+            log.info("Successfully deleted S3 object. URL: {}", fileUrl);
+        } catch (Exception e) {
+            // 스토리지 삭제 실패는 로그만 남기고 계속 진행 (비용 이슈지만 참조 깨짐 없음)
+            log.error("Failed to delete S3 object (best-effort). URL: {}", fileUrl, e);
         }
     }
 }

--- a/src/main/java/com/gemmap/gemmap/spot/domain/repository/SpotPhotoRepository.java
+++ b/src/main/java/com/gemmap/gemmap/spot/domain/repository/SpotPhotoRepository.java
@@ -1,7 +1,11 @@
 package com.gemmap.gemmap.spot.domain.repository;
 
+import com.gemmap.gemmap.spot.domain.entity.Spot;
 import com.gemmap.gemmap.spot.domain.entity.SpotPhoto;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface SpotPhotoRepository extends JpaRepository<SpotPhoto, Long> {
+    List<SpotPhoto> findBySpot(Spot spot);
 }

--- a/src/main/java/com/gemmap/gemmap/spot/presentation/SpotController.java
+++ b/src/main/java/com/gemmap/gemmap/spot/presentation/SpotController.java
@@ -41,4 +41,13 @@ public class SpotController {
         );
         return ResponseDto.created(spotService.create(userId, request, file));
     }
+
+    @DeleteMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseDto<?> delete(
+            @UserId Long userId,
+            @RequestParam(value = "spotId") Long spotId
+    ) {
+        spotService.delete(userId, spotId);
+        return ResponseDto.noContent();
+    }
 }


### PR DESCRIPTION
## 요약
스팟 삭제 API를 구현하여 사용자가 자신이 생성한 스팟과 연결된 사진들을 삭제

<br>

## 작업 내용
- `DELETE /api/v1/spots` 엔드포인트 추가
    - multipart/form-data 형식으로 spotId 수신
    - 204 No Content 응답 반환
- 입력 검증
    - spotId 필수 검증 (null 시 400 에러)
    - 사용자 존재 확인 (미존재 시 404 에러)
    - Spot 존재 확인 (미존재 시 404 에러)
    - 소유권 검증 (불일치 시 403 에러)
- 삭제 로직 구현
    - DB 우선 삭제: @Transactional 내에서 spot_photos → spots 순서로 삭제
    - Object Storage 삭제: 트랜잭션 커밋 후 베스트 에포트로 S3 객체 삭제
    - 스토리지 삭제 실패 시 로그만 남기고 성공 응답 (참조 무결성 유지)
- 멀티 포토 지원
    - SpotPhotoRepository.findBySpot() 반환 타입을 List<SpotPhoto>로 변경
    - 하나의 Spot에 여러 SpotPhoto가 연결된 경우 모두 삭제 처리

<br>

## 참고 사항
- 정합성 전략: DB 삭제 우선 → 스토리지 삭제 베스트 에포트
    - DB 삭제 실패 시 롤백되어 안전
    - 스토리지 삭제 실패 시 비용 이슈는 있지만 참조 깨짐은 없음
- cascade 미설정: SpotPhoto-Spot 간 cascade 없어 명시적 순서 삭제 (추후 설정 예정)
- ResponseDtoAdvice 주석 처리: 별도 이슈로 처리 예정

<br>

## 관련 이슈
- #38

<br>