### PR TITLE
Feat(spot): Add spot detail retrieval API

### DIFF
--- a/src/main/java/com/gemmap/gemmap/shared/common/enums/ESpotPhotoType.java
+++ b/src/main/java/com/gemmap/gemmap/shared/common/enums/ESpotPhotoType.java
@@ -1,0 +1,5 @@
+package com.gemmap.gemmap.shared.common.enums;
+
+public enum ESpotPhotoType {
+    SPOT, CHECKIN
+}

--- a/src/main/java/com/gemmap/gemmap/shared/exception/ErrorCode.java
+++ b/src/main/java/com/gemmap/gemmap/shared/exception/ErrorCode.java
@@ -38,6 +38,8 @@ public enum ErrorCode {
     // 404 Not Found
     RESOURCE_NOT_FOUND(40400, HttpStatus.NOT_FOUND, "요청한 리소스를 찾을 수 없습니다."),
     USER_NOT_FOUND(40401, HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
+    SPOT_NOT_FOUND(40402, HttpStatus.NOT_FOUND, "스팟을 찾을 수 없습니다."),
+    SPOT_PHOTO_NOT_FOUND(40403, HttpStatus.NOT_FOUND, "스팟 사진을 찾을 수 없습니다."),
 
     // 409 Conflict
     CONFLICT(40900, HttpStatus.CONFLICT, "요청이 현재 리소스 상태와 충돌합니다."),

--- a/src/main/java/com/gemmap/gemmap/spot/application/dto/response/SpotDetailResponse.java
+++ b/src/main/java/com/gemmap/gemmap/spot/application/dto/response/SpotDetailResponse.java
@@ -1,0 +1,74 @@
+package com.gemmap.gemmap.spot.application.dto.response;
+
+import com.gemmap.gemmap.auth.domain.entity.User;
+import com.gemmap.gemmap.spot.domain.entity.Spot;
+import com.gemmap.gemmap.spot.domain.entity.SpotPhoto;
+import lombok.Builder;
+
+import java.math.BigDecimal;
+import java.time.*;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+
+@Builder
+public record SpotDetailResponse(
+        Long spotId,            // 스팟 ID
+        String profileImage,    // 사용자 프로필 이미지
+        String nickname,        // 사용자 닉네임
+        String alias,           // 스팟 별칭
+        String fileUrl,         // 사진 URL
+        String address,         // 도로명주소
+        String takenAt,         // 촬영시각(UTC, ISO-8601 Z)
+        BigDecimal latitude,    // 위도
+        BigDecimal longitude,   // 경도
+        String cameraMake,      // 카메라 브랜드
+        String cameraModel,     // 카메라 모델
+        BigDecimal aperture,    // 조리개
+        String shutterSpeed,    // 셔터속도
+        Integer iso,            // ISO
+        BigDecimal focalLength, // 초점거리
+        String createdAt        // 생성시각(스팟, UTC, ISO-8601 Z)
+) {
+
+    public static SpotDetailResponse from (Spot spot, User spotOwner, SpotPhoto photo) {
+        return SpotDetailResponse.builder()
+                .spotId(spot.getId())
+                .profileImage(spotOwner.getProfileImage())
+                .nickname(spotOwner.getNickname())
+                .alias(spot.getAlias())
+                .fileUrl(photo.getFileUrl())
+                .address(spot.getAddress())
+                .takenAt(toUtcIso(photo.getTakenAt())) // LocalDateTime/Instant/OffsetDateTime 대응
+                .latitude(photo.getLatitude())
+                .longitude(photo.getLongitude())
+                .cameraMake(photo.getCameraMake())
+                .cameraModel(photo.getCameraModel())
+                .aperture(photo.getAperture())
+                .shutterSpeed(photo.getShutterSpeed())
+                .iso(photo.getIso())
+                .focalLength(photo.getFocalLength())
+                .createdAt(toUtcIso(spot.getCreatedAt()))
+                .build();
+    }
+
+    // 시간 포맷터 (UTC ISO_INSTANT)
+    private static String toUtcIso(Object temporal) {
+        if (temporal == null) return null;
+        Instant instant;
+
+        if (temporal instanceof Instant i) {
+            instant = i;
+        } else if (temporal instanceof LocalDateTime ldt) {
+            instant = ldt.atZone(ZoneId.systemDefault()).toInstant();
+        } else if (temporal instanceof OffsetDateTime odt) {
+            instant = odt.toInstant();
+        } else if (temporal instanceof ZonedDateTime zdt) {
+            instant = zdt.toInstant();
+        } else {
+            throw new IllegalArgumentException("Unsupported temporal type: " + temporal.getClass());
+        }
+
+        instant = instant.truncatedTo(ChronoUnit.SECONDS);
+        return DateTimeFormatter.ISO_INSTANT.format(instant); // ex) 2025-10-23T11:22:33Z
+    }
+}

--- a/src/main/java/com/gemmap/gemmap/spot/application/service/SpotService.java
+++ b/src/main/java/com/gemmap/gemmap/spot/application/service/SpotService.java
@@ -4,11 +4,13 @@ import com.gemmap.gemmap.auth.domain.entity.User;
 import com.gemmap.gemmap.auth.domain.repository.UserRepository;
 import com.gemmap.gemmap.image.infrastructure.objectstorage.ObjectStorageService;
 import com.gemmap.gemmap.image.infrastructure.objectstorage.S3UrlGenerator;
+import com.gemmap.gemmap.shared.common.enums.ESpotPhotoType;
 import com.gemmap.gemmap.shared.config.s3.S3Properties;
 import com.gemmap.gemmap.shared.exception.CommonException;
 import com.gemmap.gemmap.shared.exception.ErrorCode;
 import com.gemmap.gemmap.spot.application.dto.request.SpotCreateRequest;
 import com.gemmap.gemmap.spot.application.dto.response.SpotCreateResponse;
+import com.gemmap.gemmap.spot.application.dto.response.SpotDetailResponse;
 import com.gemmap.gemmap.spot.application.support.SpotFileValidator;
 import com.gemmap.gemmap.spot.domain.entity.Spot;
 import com.gemmap.gemmap.spot.domain.entity.SpotPhoto;
@@ -81,7 +83,7 @@ public class SpotService {
             SpotPhoto photo = SpotPhoto.builder()
                 .spot(spot)
                 .fileUrl(fileUrl)
-                .type(SpotPhoto.Type.SPOT)
+                .type(ESpotPhotoType.SPOT)
                 .takenAt(parseUtc(req.takenAt()))
                 .latitude(req.latitude())
                 .longitude(req.longitude())
@@ -158,7 +160,7 @@ public class SpotService {
 
         // 2) Spot 존재 확인
         Spot spot = spotRepository.findById(spotId)
-            .orElseThrow(() -> new CommonException(ErrorCode.RESOURCE_NOT_FOUND, "스팟을 찾을 수 없습니다."));
+            .orElseThrow(() -> new CommonException(ErrorCode.SPOT_NOT_FOUND));
 
         // 3) 소유권 검증
         if (!spot.getUserId().equals(userId)) {
@@ -193,5 +195,35 @@ public class SpotService {
             // 스토리지 삭제 실패는 로그만 남기고 계속 진행 (비용 이슈지만 참조 깨짐 없음)
             log.error("Failed to delete S3 object (best-effort). URL: {}", fileUrl, e);
         }
+    }
+
+    /**
+     * 스팟 상세 조회
+     *
+     * @param userId 요청 사용자 ID (인증용, 현재는 조회만 수행)
+     * @param spotId 조회할 스팟 ID
+     * @return SpotDetailResponse
+     */
+    @Transactional(readOnly = true)
+    public SpotDetailResponse getSpotDetail(Long userId, Long spotId) {
+        // 1) 사용자 조회 (인증 확인)
+        userRepository.findById(userId)
+                .orElseThrow(() -> new CommonException(ErrorCode.USER_NOT_FOUND));
+
+        // 2) Spot 조회
+        Spot spot = spotRepository.findById(spotId)
+                .orElseThrow(() -> new CommonException(ErrorCode.SPOT_NOT_FOUND));
+
+        // 3) Spot 작성자(소유자) 조회
+        User spotOwner = userRepository.findById(spot.getUserId())
+                .orElseThrow(() -> new CommonException(ErrorCode.USER_NOT_FOUND, "스팟 등록자를 찾을 수 없습니다."));
+
+        // 4) 대표 사진 조회 (최신 1건)
+        SpotPhoto representativePhoto = spotPhotoRepository.
+                findFirstBySpotAndTypeOrderByCreatedAtDesc(spot, ESpotPhotoType.SPOT)
+                .orElseThrow(() -> new CommonException(ErrorCode.SPOT_PHOTO_NOT_FOUND, "스팟 사진이 존재하지 않습니다."));
+
+        // 5) 응답 DTO 변환
+        return SpotDetailResponse.from(spot, spotOwner, representativePhoto);
     }
 }

--- a/src/main/java/com/gemmap/gemmap/spot/application/service/SpotService.java
+++ b/src/main/java/com/gemmap/gemmap/spot/application/service/SpotService.java
@@ -46,6 +46,14 @@ public class SpotService {
     private final S3Properties s3Properties;
     private final SpotFileValidator spotFileValidator;
 
+    /**
+     * 스팟 생성
+     *
+     * @param userId 요청 사용자 ID
+     * @param req 스팟 생성 요청 DTO
+     * @param file 업로드할 이미지 파일
+     * @return SpotCreateResponse
+     */
     @Transactional
     public SpotCreateResponse create(Long userId, SpotCreateRequest req, MultipartFile file) {
         // 1) 사용자 조회

--- a/src/main/java/com/gemmap/gemmap/spot/domain/entity/SpotPhoto.java
+++ b/src/main/java/com/gemmap/gemmap/spot/domain/entity/SpotPhoto.java
@@ -1,5 +1,6 @@
 package com.gemmap.gemmap.spot.domain.entity;
 
+import com.gemmap.gemmap.shared.common.enums.ESpotPhotoType;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
@@ -26,11 +27,9 @@ public class SpotPhoto {
     @Column(name = "file_url", nullable = false, length = 500)
     private String fileUrl; // 오브젝트 스토리지 URL
 
-    public enum Type { SPOT, CHECKIN }
-
+    @Column(name = "type", nullable = false)
     @Enumerated(EnumType.STRING)
-    @Column(name = "type", nullable = false, columnDefinition = "enum('SPOT','CHECKIN') default 'SPOT'")
-    private Type type; // 업로드 목적
+    private ESpotPhotoType type; // 업로드 목적
 
     @Column(name = "taken_at")
     private LocalDateTime takenAt; // 촬영 시각 (UTC 저장)

--- a/src/main/java/com/gemmap/gemmap/spot/domain/repository/SpotPhotoRepository.java
+++ b/src/main/java/com/gemmap/gemmap/spot/domain/repository/SpotPhotoRepository.java
@@ -1,11 +1,16 @@
 package com.gemmap.gemmap.spot.domain.repository;
 
+import com.gemmap.gemmap.shared.common.enums.ESpotPhotoType;
 import com.gemmap.gemmap.spot.domain.entity.Spot;
 import com.gemmap.gemmap.spot.domain.entity.SpotPhoto;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface SpotPhotoRepository extends JpaRepository<SpotPhoto, Long> {
     List<SpotPhoto> findBySpot(Spot spot);
+
+    // 특정 스팟의 type이 SPOT인 대표 사진 조회 (최신 1건)
+    Optional<SpotPhoto> findFirstBySpotAndTypeOrderByCreatedAtDesc(Spot spot, ESpotPhotoType type);
 }

--- a/src/main/java/com/gemmap/gemmap/spot/presentation/SpotController.java
+++ b/src/main/java/com/gemmap/gemmap/spot/presentation/SpotController.java
@@ -20,6 +20,24 @@ public class SpotController {
 
     private final SpotService spotService;
 
+    /**
+     * 스팟 생성
+     *
+     * @param userId 인증된 사용자 ID
+     * @param file 업로드할 이미지 파일
+     * @param alias 스팟 별칭
+     * @param address 도로명 주소
+     * @param takenAt 촬영 시각 (UTC ISO8601 형식, optional)
+     * @param latitude 위도
+     * @param longitude 경도
+     * @param cameraMake 카메라 브랜드 (optional)
+     * @param cameraModel 카메라 모델 (optional)
+     * @param aperture 조리개 값 (optional)
+     * @param shutterSpeed 셔터 속도 (optional)
+     * @param iso ISO 값 (optional)
+     * @param focalLength 초점 거리 (optional)
+     * @return 생성된 스팟 정보
+     */
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseDto<SpotCreateResponse> create(
             @UserId Long userId,
@@ -43,6 +61,13 @@ public class SpotController {
         return ResponseDto.created(spotService.create(userId, request, file));
     }
 
+    /**
+     * 스팟 삭제
+     *
+     * @param userId 인증된 사용자 ID
+     * @param spotId 삭제할 스팟 ID
+     * @return 삭제 성공 응답
+     */
     @DeleteMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseDto<?> delete(
             @UserId Long userId,

--- a/src/main/java/com/gemmap/gemmap/spot/presentation/SpotController.java
+++ b/src/main/java/com/gemmap/gemmap/spot/presentation/SpotController.java
@@ -4,6 +4,7 @@ import com.gemmap.gemmap.shared.common.annotation.UserId;
 import com.gemmap.gemmap.shared.common.dto.ResponseDto;
 import com.gemmap.gemmap.spot.application.dto.request.SpotCreateRequest;
 import com.gemmap.gemmap.spot.application.dto.response.SpotCreateResponse;
+import com.gemmap.gemmap.spot.application.dto.response.SpotDetailResponse;
 import com.gemmap.gemmap.spot.application.service.SpotService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
@@ -49,5 +50,20 @@ public class SpotController {
     ) {
         spotService.delete(userId, spotId);
         return ResponseDto.noContent();
+    }
+
+    /**
+     * 스팟 상세 조회
+     *
+     * @param userId 인증된 사용자 ID
+     * @param spotId 조회할 스팟 ID
+     * @return 스팟 상세 정보
+     */
+    @GetMapping("/{spotId}")
+    public ResponseDto<SpotDetailResponse> getSpotDetail(
+            @UserId Long userId,
+            @PathVariable Long spotId
+    ) {
+        return ResponseDto.ok(spotService.getSpotDetail(userId, spotId));
     }
 }

--- a/src/test/java/com/gemmap/gemmap/spot/presentation/SpotControllerIT.java
+++ b/src/test/java/com/gemmap/gemmap/spot/presentation/SpotControllerIT.java
@@ -2,6 +2,7 @@ package com.gemmap.gemmap.spot.presentation;
 
 import com.gemmap.gemmap.auth.infrastructure.jwt.JwtUtil;
 import com.gemmap.gemmap.shared.common.enums.ERole;
+import com.gemmap.gemmap.shared.common.enums.ESpotPhotoType;
 import com.gemmap.gemmap.spot.domain.entity.Spot;
 import com.gemmap.gemmap.spot.domain.entity.SpotPhoto;
 import com.gemmap.gemmap.spot.domain.repository.SpotPhotoRepository;
@@ -96,7 +97,7 @@ class SpotControllerIT {
 
         List<SpotPhoto> photos = spotPhotoRepository.findAll();
         assertThat(photos).hasSize(1);
-        assertThat(photos.get(0).getType()).isEqualTo(SpotPhoto.Type.SPOT);
+        assertThat(photos.get(0).getType()).isEqualTo(ESpotPhotoType.SPOT);
         assertThat(photos.get(0).getFileUrl()).contains("spots/");
     }
 


### PR DESCRIPTION
## 요약
스팟 상세 조회 API를 구현하고 기존 API 메서드들에 JavaDoc 주석을 추가

<br>

## 작업 내용
- GET /api/v1/spots/{spotId} 엔드포인트 추가
- SpotDetailResponse DTO 구현 (스팟 정보, 작성자 정보, 대표 사진 정보 포함)
- ESpotPhotoType 열거형 추가 (사진 타입 구분)
- SpotPhotoRepository에 타입별 조회 메서드 추가
- SPOT/SPOT_PHOTO NOT_FOUND 에러 코드 추가
- SpotController 및 SpotService의 create, delete 메서드에 JavaDoc 주석 추가

<br>

## 참고 사항
- 대표 사진은 type=SPOT인 사진 중 최신 1건을 조회
- 모든 시간 정보는 UTC ISO-8601 형식(Z)으로 반환
- 인증된 사용자만 스팟 상세 정보를 조회할 수 있음

<br>

## 관련 이슈
- #40 

<br>