### PR TITLE
Feat(spot): Add my spots retrieval API

### DIFF
--- a/src/main/java/com/gemmap/gemmap/spot/application/dto/response/MySpotsResponse.java
+++ b/src/main/java/com/gemmap/gemmap/spot/application/dto/response/MySpotsResponse.java
@@ -1,0 +1,26 @@
+package com.gemmap.gemmap.spot.application.dto.response;
+
+import com.gemmap.gemmap.auth.domain.entity.User;
+import lombok.Builder;
+
+import java.util.List;
+
+/**
+ * 내가 제보한 스팟 목록 응답 DTO
+ */
+@Builder
+public record MySpotsResponse(
+        String profileImage,    // 사용자 프로필 이미지
+        String nickname,        // 사용자 닉네임
+        Integer mySpotCount,    // 제보한 젬 개수 (전체)
+        List<SpotSummary> spots // 제보한 젬 목록
+) {
+    public static MySpotsResponse of(User user, Integer totalCount, List<SpotSummary> spots) {
+        return MySpotsResponse.builder()
+                .profileImage(user.getProfileImage())
+                .nickname(user.getNickname())
+                .mySpotCount(totalCount)
+                .spots(spots)
+                .build();
+    }
+}

--- a/src/main/java/com/gemmap/gemmap/spot/application/dto/response/SpotSummary.java
+++ b/src/main/java/com/gemmap/gemmap/spot/application/dto/response/SpotSummary.java
@@ -1,0 +1,24 @@
+package com.gemmap.gemmap.spot.application.dto.response;
+
+import com.gemmap.gemmap.spot.domain.entity.Spot;
+import lombok.Builder;
+
+/**
+ * 스팟 요약 정보 DTO (내가 제보한 스팟 목록용)
+ */
+@Builder
+public record SpotSummary(
+        Long spotId,       // 스팟 ID
+        String fileUrl,    // 사진 URL
+        String alias,      // 스팟 별칭
+        String address     // 도로명주소
+) {
+    public static SpotSummary of(Spot spot, String fileUrl) {
+        return SpotSummary.builder()
+                .spotId(spot.getId())
+                .fileUrl(fileUrl)
+                .alias(spot.getAlias())
+                .address(spot.getAddress())
+                .build();
+    }
+}

--- a/src/main/java/com/gemmap/gemmap/spot/application/service/SpotService.java
+++ b/src/main/java/com/gemmap/gemmap/spot/application/service/SpotService.java
@@ -9,8 +9,10 @@ import com.gemmap.gemmap.shared.config.s3.S3Properties;
 import com.gemmap.gemmap.shared.exception.CommonException;
 import com.gemmap.gemmap.shared.exception.ErrorCode;
 import com.gemmap.gemmap.spot.application.dto.request.SpotCreateRequest;
+import com.gemmap.gemmap.spot.application.dto.response.MySpotsResponse;
 import com.gemmap.gemmap.spot.application.dto.response.SpotCreateResponse;
 import com.gemmap.gemmap.spot.application.dto.response.SpotDetailResponse;
+import com.gemmap.gemmap.spot.application.dto.response.SpotSummary;
 import com.gemmap.gemmap.spot.application.support.SpotFileValidator;
 import com.gemmap.gemmap.spot.domain.entity.Spot;
 import com.gemmap.gemmap.spot.domain.entity.SpotPhoto;
@@ -32,6 +34,7 @@ import java.time.format.DateTimeParseException;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -57,7 +60,7 @@ public class SpotService {
     @Transactional
     public SpotCreateResponse create(Long userId, SpotCreateRequest req, MultipartFile file) {
         // 1) 사용자 조회
-        userRepository.findById(userId)
+        User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CommonException(ErrorCode.USER_NOT_FOUND));
 
         // 2) 요청 검증 (빠른 실패 우선: 좌표 검증 -> 파일 검증)
@@ -81,15 +84,16 @@ public class SpotService {
             // 4) spots 저장
             Spot spot = spotRepository.save(
                 Spot.builder()
-                    .userId(userId)
+                    .user(user)
                     .address(req.address())
                     .alias(req.alias())
                     .build()
             );
 
-            // 5) spot_photos 저장 (type=SPOT, fileUrl 직접 저장)
+            // 5) spot_photos 저장 (type=SPOT, fileUrl 직접 저장, user 저장)
             SpotPhoto photo = SpotPhoto.builder()
                 .spot(spot)
+                .user(user)
                 .fileUrl(fileUrl)
                 .type(ESpotPhotoType.SPOT)
                 .takenAt(parseUtc(req.takenAt()))
@@ -163,7 +167,7 @@ public class SpotService {
     @Transactional
     public void delete(Long userId, Long spotId) {
         // 1) 사용자 조회
-        userRepository.findById(userId)
+        User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CommonException(ErrorCode.USER_NOT_FOUND));
 
         // 2) Spot 존재 확인
@@ -171,7 +175,7 @@ public class SpotService {
             .orElseThrow(() -> new CommonException(ErrorCode.SPOT_NOT_FOUND));
 
         // 3) 소유권 검증
-        if (!spot.getUserId().equals(userId)) {
+        if (!spot.getUser().equals(user)) {
             throw new CommonException(ErrorCode.ACCESS_DENIED, "해당 스팟을 삭제할 권한이 없습니다.");
         }
 
@@ -223,7 +227,7 @@ public class SpotService {
                 .orElseThrow(() -> new CommonException(ErrorCode.SPOT_NOT_FOUND));
 
         // 3) Spot 작성자(소유자) 조회
-        User spotOwner = userRepository.findById(spot.getUserId())
+        User spotOwner = userRepository.findById(spot.getUser().getId())
                 .orElseThrow(() -> new CommonException(ErrorCode.USER_NOT_FOUND, "스팟 등록자를 찾을 수 없습니다."));
 
         // 4) 대표 사진 조회 (최신 1건)
@@ -233,5 +237,43 @@ public class SpotService {
 
         // 5) 응답 DTO 변환
         return SpotDetailResponse.from(spot, spotOwner, representativePhoto);
+    }
+
+    /**
+     * 내가 제보한 스팟 목록 조회
+     *
+     * @param userId 요청 사용자 ID
+     * @return MySpotsResponse
+     */
+    @Transactional(readOnly = true)
+    public MySpotsResponse getMySpots(Long userId) {
+        // 1) 사용자 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CommonException(ErrorCode.USER_NOT_FOUND));
+
+        // 2) 사용자가 등록한 스팟 전체 개수 조회
+        Integer totalCount = spotRepository.countByUser(user);
+
+        // 3) 사용자가 등록한 스팟 목록 조회 (최신순)
+        List<Spot> spots = spotRepository.findByUserOrderByCreatedAtDesc(user);
+
+        // 4) 각 스팟에 대한 사진(type=SPOT, user=요청 사용자) 조회 후 DTO 변환
+        //    - 사진 없으면 해당 스팟은 노출하되 fileUrl = null
+        //    - 스팟 목록 자체가 없으면 자연스럽게 빈 리스트 반환
+        // TODO: N+1 문제 보완 가능 - @EntityGraph 또는 Batch Fetch 전략 고려
+        // 현재 요구사항에서는 per-spot 1회 조회로 충분하나, 스팟이 많아질 경우 최적화 필요
+        List<SpotSummary> spotSummaries = spots.stream()
+                .map(spot -> {
+                    // 각 spot마다 DB 쿼리 1회 발생 → N+1 문제
+                    String fileUrl = spotPhotoRepository
+                            .findFirstBySpotAndUserAndTypeOrderByCreatedAtDesc(spot, user, ESpotPhotoType.SPOT)
+                            .map(SpotPhoto::getFileUrl)
+                            .orElse(null);
+                    return SpotSummary.of(spot, fileUrl);
+                })
+                .collect(Collectors.toList());
+
+        // 5) 응답 DTO 변환
+        return MySpotsResponse.of(user, totalCount, spotSummaries);
     }
 }

--- a/src/main/java/com/gemmap/gemmap/spot/domain/entity/Spot.java
+++ b/src/main/java/com/gemmap/gemmap/spot/domain/entity/Spot.java
@@ -1,5 +1,6 @@
 package com.gemmap.gemmap.spot.domain.entity;
 
+import com.gemmap.gemmap.auth.domain.entity.User;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
@@ -18,8 +19,9 @@ public class Spot {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id; // 스팟 id
 
-    @Column(name = "user_id", nullable = false, updatable = false)
-    private Long userId; // 생성자 (사용자 id)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user; // 생성자 (사용자 id)
 
     @Column(length = 400, nullable = false)
     private String address; // 도로명주소

--- a/src/main/java/com/gemmap/gemmap/spot/domain/entity/SpotPhoto.java
+++ b/src/main/java/com/gemmap/gemmap/spot/domain/entity/SpotPhoto.java
@@ -1,5 +1,6 @@
 package com.gemmap.gemmap.spot.domain.entity;
 
+import com.gemmap.gemmap.auth.domain.entity.User;
 import com.gemmap.gemmap.shared.common.enums.ESpotPhotoType;
 import jakarta.persistence.*;
 import lombok.*;
@@ -23,6 +24,10 @@ public class SpotPhoto {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "spot_id", nullable = false)
     private Spot spot; // 스팟 id
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user; // 사진 등록자 (사용자 id)
 
     @Column(name = "file_url", nullable = false, length = 500)
     private String fileUrl; // 오브젝트 스토리지 URL

--- a/src/main/java/com/gemmap/gemmap/spot/domain/repository/SpotPhotoRepository.java
+++ b/src/main/java/com/gemmap/gemmap/spot/domain/repository/SpotPhotoRepository.java
@@ -1,5 +1,6 @@
 package com.gemmap.gemmap.spot.domain.repository;
 
+import com.gemmap.gemmap.auth.domain.entity.User;
 import com.gemmap.gemmap.shared.common.enums.ESpotPhotoType;
 import com.gemmap.gemmap.spot.domain.entity.Spot;
 import com.gemmap.gemmap.spot.domain.entity.SpotPhoto;
@@ -11,6 +12,19 @@ import java.util.Optional;
 public interface SpotPhotoRepository extends JpaRepository<SpotPhoto, Long> {
     List<SpotPhoto> findBySpot(Spot spot);
 
-    // 특정 스팟의 type이 SPOT인 대표 사진 조회 (최신 1건)
+    /**
+     * 특정 스팟의 type이 SPOT인 대표 사진 조회 (최신 1건)
+     */
     Optional<SpotPhoto> findFirstBySpotAndTypeOrderByCreatedAtDesc(Spot spot, ESpotPhotoType type);
+
+    /**
+     * 특정 스팟 + 특정 사용자 + 특정 타입의 대표 사진 조회 (최신순)
+     * 내가 제보한 스팟 목록 조회 시 사용
+     *
+     * @param spot 스팟
+     * @param user 사용자
+     * @param type 사진 타입
+     * @return 대표 사진
+     */
+    Optional<SpotPhoto> findFirstBySpotAndUserAndTypeOrderByCreatedAtDesc(Spot spot, User user, ESpotPhotoType type);
 }

--- a/src/main/java/com/gemmap/gemmap/spot/domain/repository/SpotRepository.java
+++ b/src/main/java/com/gemmap/gemmap/spot/domain/repository/SpotRepository.java
@@ -1,7 +1,26 @@
 package com.gemmap.gemmap.spot.domain.repository;
 
+import com.gemmap.gemmap.auth.domain.entity.User;
 import com.gemmap.gemmap.spot.domain.entity.Spot;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface SpotRepository extends JpaRepository<Spot, Long> {
+
+    /**
+     * 특정 사용자가 생성한 스팟 목록 조회 (최신순)
+     *
+     * @param user 사용자
+     * @return 스팟 목록
+     */
+    List<Spot> findByUserOrderByCreatedAtDesc(User user);
+
+    /**
+     * 특정 사용자가 생성한 스팟 개수 조회
+     *
+     * @param user 사용자
+     * @return 스팟 개수
+     */
+    Integer countByUser(User user);
 }

--- a/src/main/java/com/gemmap/gemmap/spot/presentation/SpotController.java
+++ b/src/main/java/com/gemmap/gemmap/spot/presentation/SpotController.java
@@ -3,6 +3,7 @@ package com.gemmap.gemmap.spot.presentation;
 import com.gemmap.gemmap.shared.common.annotation.UserId;
 import com.gemmap.gemmap.shared.common.dto.ResponseDto;
 import com.gemmap.gemmap.spot.application.dto.request.SpotCreateRequest;
+import com.gemmap.gemmap.spot.application.dto.response.MySpotsResponse;
 import com.gemmap.gemmap.spot.application.dto.response.SpotCreateResponse;
 import com.gemmap.gemmap.spot.application.dto.response.SpotDetailResponse;
 import com.gemmap.gemmap.spot.application.service.SpotService;
@@ -90,5 +91,18 @@ public class SpotController {
             @PathVariable Long spotId
     ) {
         return ResponseDto.ok(spotService.getSpotDetail(userId, spotId));
+    }
+
+    /**
+     * 내가 제보한 스팟 목록 조회
+     *
+     * @param userId 인증된 사용자 ID
+     * @return 내가 제보한 스팟 목록 (프로필 정보 + 스팟 목록)
+     */
+    @GetMapping("/me")
+    public ResponseDto<MySpotsResponse> getMySpots(
+            @UserId Long userId
+    ) {
+        return ResponseDto.ok(spotService.getMySpots(userId));
     }
 }


### PR DESCRIPTION
## 요약
사용자가 제보한 스팟 목록 조회 API를 구현하고, Spot/SpotPhoto 엔티티를 User와 연관관계로 리팩토링

<br>

## 작업 내용
- GET /api/v1/spots/me 엔드포인트 추가
- MySpotsResponse, SpotSummary 응답 DTO 구현
- Spot 엔티티: userId(Long) → user(User) 관계로 변경
- SpotPhoto 엔티티: userId 필드 → user(User) 관계로 추가
- SpotRepository: findByUserOrderByCreatedAtDesc, countByUser 메서드 추가
- SpotPhotoRepository: findFirstBySpotAndUserAndTypeOrderByCreatedAtDesc 메서드 추가
- 기존 create, delete, getSpotDetail 메서드 User 엔티티 사용으로 리팩토링

<br>

## 참고 사항
- 응답에는 사용자 프로필 정보(profileImage, nickname)와 전체 제보 개수(mySpotCount), 스팟 목록(spots)을 포함
- 각 스팟의 대표 사진은 type=SPOT, 해당 사용자가 업로드한 최신 사진으로 선정
- N+1 문제 가능성이 있으나, 현재 요구사항에서는 충분하며 향후 최적화 가능하도록 TODO 주석 추가
- 엔티티 연관관계 변경으로 코드 가독성과 타입 안전성 향상

<br>

## 관련 이슈
- #42 

<br>