### PR TITLE
Feat(spot): Add spot markers retrieval API for map display

### DIFF
--- a/src/main/java/com/gemmap/gemmap/spot/application/dto/response/SpotMakerInfo.java
+++ b/src/main/java/com/gemmap/gemmap/spot/application/dto/response/SpotMakerInfo.java
@@ -1,0 +1,17 @@
+package com.gemmap.gemmap.spot.application.dto.response;
+
+import com.gemmap.gemmap.spot.domain.entity.Spot;
+import com.gemmap.gemmap.spot.domain.entity.SpotPhoto;
+import lombok.Builder;
+
+import java.math.BigDecimal;
+
+/**
+ * 마커 정보 DTO (지도 전체 마커 조회용)
+ */
+@Builder
+public record SpotMakerInfo(
+        Long spotId,            // 스팟 ID
+        BigDecimal latitude,    // 위도
+        BigDecimal longitude    // 경도
+) {}

--- a/src/main/java/com/gemmap/gemmap/spot/application/dto/response/SpotsResponse.java
+++ b/src/main/java/com/gemmap/gemmap/spot/application/dto/response/SpotsResponse.java
@@ -1,0 +1,19 @@
+package com.gemmap.gemmap.spot.application.dto.response;
+
+import lombok.Builder;
+
+import java.util.List;
+
+/**
+ * 지도 전체 마커 조회 응답 DTO
+ */
+@Builder
+public record SpotsResponse(
+        List<SpotMakerInfo> spots // 제보한 젬 목록
+) {
+    public static SpotsResponse of(List<SpotMakerInfo> spots) {
+        return SpotsResponse.builder()
+                .spots(spots)
+                .build();
+    }
+}

--- a/src/main/java/com/gemmap/gemmap/spot/application/service/SpotService.java
+++ b/src/main/java/com/gemmap/gemmap/spot/application/service/SpotService.java
@@ -9,10 +9,7 @@ import com.gemmap.gemmap.shared.config.s3.S3Properties;
 import com.gemmap.gemmap.shared.exception.CommonException;
 import com.gemmap.gemmap.shared.exception.ErrorCode;
 import com.gemmap.gemmap.spot.application.dto.request.SpotCreateRequest;
-import com.gemmap.gemmap.spot.application.dto.response.MySpotsResponse;
-import com.gemmap.gemmap.spot.application.dto.response.SpotCreateResponse;
-import com.gemmap.gemmap.spot.application.dto.response.SpotDetailResponse;
-import com.gemmap.gemmap.spot.application.dto.response.SpotSummary;
+import com.gemmap.gemmap.spot.application.dto.response.*;
 import com.gemmap.gemmap.spot.application.support.SpotFileValidator;
 import com.gemmap.gemmap.spot.domain.entity.Spot;
 import com.gemmap.gemmap.spot.domain.entity.SpotPhoto;
@@ -275,5 +272,25 @@ public class SpotService {
 
         // 5) 응답 DTO 변환
         return MySpotsResponse.of(user, totalCount, spotSummaries);
+    }
+
+    /**
+     * 지도 전체 마커 조회
+     *
+     * @param userId 인증된 사용자 ID
+     * @return SpotsResponse
+     */
+    @Transactional(readOnly = true)
+    public SpotsResponse getSpots(Long userId) {
+        // 1) 사용자 조회 (인증 확인)
+        userRepository.findById(userId)
+                .orElseThrow(() -> new CommonException(ErrorCode.USER_NOT_FOUND));
+
+        // 2) 전체 스팟과 최신 사진 위치 정보를 한 번의 쿼리로 조회 (N+1 문제 해결)
+        //    JOIN 쿼리를 사용하여 각 스팟의 가장 최근 SPOT 타입 사진의 위도/경도 정보를 함께 조회
+        List<SpotMakerInfo> spotMakers = spotRepository.findAllSpotsWithLatestPhotoLocation(ESpotPhotoType.SPOT);
+
+        // 3) 응답 DTO 반환 - spotId(spots), latitude(spot_photos), longitude(spot_photos)
+        return SpotsResponse.of(spotMakers);
     }
 }

--- a/src/main/java/com/gemmap/gemmap/spot/domain/repository/SpotRepository.java
+++ b/src/main/java/com/gemmap/gemmap/spot/domain/repository/SpotRepository.java
@@ -1,8 +1,12 @@
 package com.gemmap.gemmap.spot.domain.repository;
 
 import com.gemmap.gemmap.auth.domain.entity.User;
+import com.gemmap.gemmap.shared.common.enums.ESpotPhotoType;
+import com.gemmap.gemmap.spot.application.dto.response.SpotMakerInfo;
 import com.gemmap.gemmap.spot.domain.entity.Spot;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -23,4 +27,26 @@ public interface SpotRepository extends JpaRepository<Spot, Long> {
      * @return 스팟 개수
      */
     Integer countByUser(User user);
+
+    /**
+     * 모든 스팟 조회 (지도 전체 마커 조회용)
+     *
+     * @return 스팟 목록
+     */
+    List<Spot> findAll();
+
+    /**
+     * 모든 스팟과 최신 사진 위치 정보를 한 번의 쿼리로 조회 (N+1 문제 해결)
+     * 각 스팟의 가장 최근에 생성된 SPOT 타입 사진의 위도/경도 정보를 함께 조회
+     *
+     * @param type 사진 타입 (SPOT)
+     * @return 스팟 마커 정보 목록 (spotId, latitude, longitude)
+     */
+    @Query("SELECT new com.gemmap.gemmap.spot.application.dto.response.SpotMakerInfo(s.id, sp.latitude, sp.longitude) " +
+           "FROM Spot s " +
+           "INNER JOIN SpotPhoto sp ON sp.spot.id = s.id " +
+           "WHERE sp.type = :type " +
+           "AND sp.createdAt = (SELECT MAX(sp2.createdAt) FROM SpotPhoto sp2 WHERE sp2.spot.id = s.id AND sp2.type = :type)")
+    List<SpotMakerInfo> findAllSpotsWithLatestPhotoLocation(@Param("type") ESpotPhotoType type);
+
 }

--- a/src/main/java/com/gemmap/gemmap/spot/presentation/SpotController.java
+++ b/src/main/java/com/gemmap/gemmap/spot/presentation/SpotController.java
@@ -6,6 +6,7 @@ import com.gemmap.gemmap.spot.application.dto.request.SpotCreateRequest;
 import com.gemmap.gemmap.spot.application.dto.response.MySpotsResponse;
 import com.gemmap.gemmap.spot.application.dto.response.SpotCreateResponse;
 import com.gemmap.gemmap.spot.application.dto.response.SpotDetailResponse;
+import com.gemmap.gemmap.spot.application.dto.response.SpotsResponse;
 import com.gemmap.gemmap.spot.application.service.SpotService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
@@ -104,5 +105,17 @@ public class SpotController {
             @UserId Long userId
     ) {
         return ResponseDto.ok(spotService.getMySpots(userId));
+    }
+
+    /**
+     * 지도 전체 마커 조회
+     *
+     * @param userId 인증된 사용자 ID
+     */
+    @GetMapping("/markers")
+    public ResponseDto<SpotsResponse> getSpots(
+            @UserId Long userId
+    ) {
+        return ResponseDto.ok(spotService.getSpots(userId));
     }
 }


### PR DESCRIPTION
## 요약
지도에 전체 스팟 마커를 표시하기 위한 API를 구현

<br>

## 작업 내용
- GET /api/v1/spots/markers 엔드포인트 구현
    - 인증된 사용자가 전체 스팟의 마커 정보를 조회
    - 각 스팟의 ID, 위도, 경도 정보를 반환
- SpotMakerInfo DTO 추가
    - 마커 표시에 필요한 최소 정보(spotId, latitude, longitude) 포함
- SpotsResponse DTO 추가
    - 전체 마커 목록을 감싸는 응답 구조
- SpotRepository.findAllSpotsWithLatestPhotoLocation 메서드 추가
    - JPQL JOIN 쿼리로 스팟과 최신 사진의 위치 정보를 효율적으로 조회
    - 각 스팟의 가장 최근 SPOT 타입 사진 기준으로 위도/경도 추출

<br>

## 참고 사항

<br>

## 관련 이슈
- #44 

<br>