### PR TITLE
Chore(infra): Migrate infrastructure from NHN Cloud to OCI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -91,21 +91,3 @@ jobs:
           set -eux
           docker push $REGISTRY/$IMAGE_NAME:dev-$SHA7
           docker push $REGISTRY/$IMAGE_NAME:dev-latest
-
-      - name: Execute NHN Cloud Pipeline via Anchor API (dev)
-        if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
-        env:
-          NHN_REGION: KR1
-          NHN_APPKEY: ${{ secrets.NHN_APPKEY }}
-          NHN_AUTH_ID: ${{ secrets.NHN_USER_ACCESS_KEY_ID }}
-          NHN_AUTH_SECRET: ${{ secrets.NHN_USER_ACCESS_KEY_SECRET }}
-          NHN_PIPELINE: contest11-dev-pipeline
-        run: |
-          set -eux
-          curl --fail --show-error --location --max-time 20 -i -X POST \
-            -H "Content-Type:application/json" \
-            -H "X-NHN-REGION:KR1" \
-            -H "X-TC-AUTHENTICATION-ID:${NHN_AUTH_ID}" \
-            -H "X-TC-AUTHENTICATION-SECRET:${NHN_AUTH_SECRET}" \
-            -H "X-NHN-APPKEY:${NHN_APPKEY}" \
-            "https://kr1-pipeline.api.nhncloudservice.com/api/anchor/v1.0/pipelines/${NHN_PIPELINE}/execute"

--- a/.github/workflows/develop-cd.yml
+++ b/.github/workflows/develop-cd.yml
@@ -1,0 +1,122 @@
+name: CD - Deploy to Oracle Dev
+
+on:
+  workflow_run:
+    workflows: ["CI - Build & Push Docker"]
+    types: [completed]
+
+jobs:
+  deploy-dev:
+    name: Deploy to Oracle Dev
+    runs-on: ubuntu-latest
+
+    # CI 성공 + develop 브랜치일 때만 배포
+    if: >
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.head_branch == 'develop'
+
+    steps:
+      # 1. 워크플로우 디버깅용
+      - name: Print workflow_run info
+        run: |
+          echo "workflow:  ${{ github.event.workflow_run.name }}"
+          echo "branch:    ${{ github.event.workflow_run.head_branch }}"
+          echo "conclusion:${{ github.event.workflow_run.conclusion }}"
+
+      # 2. Dev 서버에서 Docker Hub 로그인
+      - name: Docker login on Dev server
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.HOST }}
+          username: ${{ secrets.USERNAME }}
+          key: ${{ secrets.PRIVATE_KEY }}
+          port: 22
+          script: |
+            set -eux
+            sudo docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
+
+      # 3. 기존 컨테이너 중지 & 제거
+      - name: Stop & remove existing gemmap-api container
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.HOST }}
+          username: ${{ secrets.USERNAME }}
+          key: ${{ secrets.PRIVATE_KEY }}
+          port: 22
+          script: |
+            set -eux
+            sudo docker stop gemmap-api || true
+            sudo docker rm -f gemmap-api || true
+
+      # 4. 최신 이미지 Pull
+      - name: Pull latest dev image
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.HOST }}
+          username: ${{ secrets.USERNAME }}
+          key: ${{ secrets.PRIVATE_KEY }}
+          port: 22
+          script: |
+            set -eux
+            REPO=${{ secrets.DOCKER_REPOSITORY }}
+            TAG=dev-latest
+
+            sudo docker pull $REPO:$TAG
+
+      # 5. 새로운 컨테이너 실행 (--net=host)
+      - name: Run new gemmap-api container
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.HOST }}
+          username: ${{ secrets.USERNAME }}
+          key: ${{ secrets.PRIVATE_KEY }}
+          port: 22
+          script: |
+            set -eux
+
+            REPO=${{ secrets.DOCKER_REPOSITORY }}
+            TAG=dev-latest
+
+            sudo docker run -d \
+              --name gemmap-api \
+              --net=host \
+              -e TZ=Asia/Seoul \
+              -e SPRING_PROFILES_ACTIVE=dev \
+              \
+              -e DB_HOST='${{ secrets.DB_HOST }}' \
+              -e DB_PORT='${{ secrets.DB_PORT }}' \
+              -e DB_NAME='${{ secrets.DB_NAME }}' \
+              -e DB_USERNAME='${{ secrets.DB_USERNAME }}' \
+              -e DB_PASSWORD='${{ secrets.DB_PASSWORD }}' \
+              \
+              -e JWT_SECRET_KEY='${{ secrets.JWT_SECRET_KEY }}' \
+              -e JWT_ACCESS_TOKEN_EXPIRATION='${{ secrets.JWT_ACCESS_TOKEN_EXPIRATION }}' \
+              -e JWT_REFRESH_TOKEN_EXPIRATION='${{ secrets.JWT_REFRESH_TOKEN_EXPIRATION }}' \
+              \
+              -e KAKAO_CLIENT_ID='${{ secrets.KAKAO_CLIENT_ID }}' \
+              -e KAKAO_CLIENT_SECRET='${{ secrets.KAKAO_CLIENT_SECRET }}' \
+              -e KAKAO_REDIRECT_URI='${{ secrets.KAKAO_REDIRECT_URI }}' \
+              -e KAKAO_APP_ID='${{ secrets.KAKAO_APP_ID }}' \
+              \
+              -e S3_ENDPOINT='${{ secrets.S3_ENDPOINT }}' \
+              -e S3_REGION='${{ secrets.S3_REGION }}' \
+              -e S3_BUCKET='${{ secrets.S3_BUCKET }}' \
+              -e S3_ACCESS_KEY='${{ secrets.S3_ACCESS_KEY }}' \
+              -e S3_SECRET_KEY='${{ secrets.S3_SECRET_KEY }}' \
+              -e S3_BASE_PATH='${{ secrets.S3_BASE_PATH }}' \
+              \
+              -e CORS_ALLOWED_ORIGINS='${{ secrets.CORS_ALLOWED_ORIGINS }}' \
+              -e CORS_MAX_AGE='${{ secrets.CORS_MAX_AGE }}' \
+              $REPO:$TAG
+
+      # 6. 오래된 이미지 정리
+      - name: Prune old Docker images
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.HOST }}
+          username: ${{ secrets.USERNAME }}
+          key: ${{ secrets.PRIVATE_KEY }}
+          port: 22
+          script: |
+            set -eux
+            sudo docker image prune -f

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,6 @@ RUN ./gradlew clean build -x test --no-daemon
 
 EXPOSE 8080
 
-ENV SPRING_PROFILES_ACTIVE=dev
+ENV JAVA_OPTS=""
 
-CMD ["java", "-jar", "build/libs/gemmap-0.0.1-SNAPSHOT.jar"]
+CMD ["sh", "-c", "java $JAVA_OPTS -jar build/libs/gemmap-0.0.1-SNAPSHOT.jar"]

--- a/src/main/java/com/gemmap/gemmap/image/infrastructure/objectstorage/S3UrlGenerator.java
+++ b/src/main/java/com/gemmap/gemmap/image/infrastructure/objectstorage/S3UrlGenerator.java
@@ -11,21 +11,23 @@ public class S3UrlGenerator {
     private final S3Properties s3Properties;
 
     /**
-     * 공개 접근 URL을 생성
+     * 공개 접근 URL을 생성 (OCI S3 호환 모드)
      * @param key S3 객체 키
      * @return 완전한 파일 URL
      */
     public String generateUrl(String key) {
-        return s3Properties.getEndpoint() + "/v1/AUTH_" + s3Properties.getTenantId() + "/" + s3Properties.getBucket() + "/" + key;
+        // OCI Object Storage S3 호환 URL 패턴: {endpoint}/{bucket}/{key}
+        return s3Properties.getEndpoint() + "/" + s3Properties.getBucket() + "/" + key;
     }
 
     /**
-     * 전체 URL에서 S3 객체 키를 추출
+     * 전체 URL에서 S3 객체 키를 추출 (OCI S3 호환 모드)
      * @param fileUrl 완전한 파일 URL
      * @return S3 객체 키
      */
     public String extractKeyFromUrl(String fileUrl) {
-        String prefix = s3Properties.getEndpoint() + "/v1/AUTH_" + s3Properties.getTenantId() + "/" + s3Properties.getBucket() + "/";
+        // OCI Object Storage S3 호환 URL 패턴: {endpoint}/{bucket}/{key}
+        String prefix = s3Properties.getEndpoint() + "/" + s3Properties.getBucket() + "/";
         if (fileUrl.startsWith(prefix)) {
             return fileUrl.substring(prefix.length());
         }

--- a/src/main/java/com/gemmap/gemmap/shared/config/s3/S3Properties.java
+++ b/src/main/java/com/gemmap/gemmap/shared/config/s3/S3Properties.java
@@ -19,8 +19,6 @@ public class S3Properties {
     @NotEmpty
     private String endpoint;
     @NotEmpty
-    private String tenantId;
-    @NotEmpty
     private String bucket;
     private String basePath;
     private boolean pathStyleAccessEnabled = true;

--- a/src/main/java/com/gemmap/gemmap/spot/application/service/SpotService.java
+++ b/src/main/java/com/gemmap/gemmap/spot/application/service/SpotService.java
@@ -20,6 +20,7 @@ import com.gemmap.gemmap.spot.domain.repository.SpotPhotoRepository;
 import com.gemmap.gemmap.spot.domain.repository.SpotRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -49,6 +50,9 @@ public class SpotService {
     private final S3Properties s3Properties;
     private final SpotFileValidator spotFileValidator;
 
+    @Value("${s3.base-path}")
+    private String basePath;
+
     /**
      * 스팟 생성
      *
@@ -67,7 +71,7 @@ public class SpotService {
         validateCoordinates(req.latitude(), req.longitude());
         spotFileValidator.validateImage(file);
 
-        // 3) 업로드 (키 규칙: spots/yyyy/MM/uuid.ext)
+        // 3) 업로드 (키 규칙 예: spots/yyyy/MM/uuid.ext)
         String key = buildSpotKey(file.getOriginalFilename());
         String fileUrl;
         try {
@@ -146,7 +150,7 @@ public class SpotService {
             .map(n -> n.substring(n.lastIndexOf('.')))
             .orElse(".jpg");
         String ym = DateTimeFormatter.ofPattern("yyyy/MM").format(LocalDate.now(ZoneOffset.UTC));
-        return "spots/" + ym + "/" + UUID.randomUUID() + ext;
+        return basePath + ym + "/" + UUID.randomUUID() + ext;
     }
 
     private void safeDeleteObject(String key) {

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -23,6 +23,9 @@ spring:
         jdbc.batch_size: 20
         default_batch_fetch_size: ${chunkSize:100}
 
+server:
+  forward-headers-strategy: framework
+
 logging:
   level:
     com.gemmap.gemmap: INFO

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -28,6 +28,10 @@ logging:
     com.gemmap.gemmap: INFO
     org.springframework.security: WARN
 
+# OCI Object Storage 설정 (S3 호환)
+s3:
+  base-path: dev/spots/
+
 # Dev 환경 설정
 cors:
   allowed-origins: ${CORS_ALLOWED_ORIGINS}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,7 +1,7 @@
 spring:
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://${DB_HOST}:${DB_PORT}/${DB_NAME}?sslMode=VERIFY_IDENTITY&serverTimezone=Asia/Seoul&enabledTLSProtocols=TLSv1.2,TLSv1.3
+    url: jdbc:mysql://${DB_HOST}:${DB_PORT}/${DB_NAME}?useSSL=false&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
     hikari:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -37,6 +37,6 @@ jwt:
   access-token-expiration: ${JWT_ACCESS_TOKEN_EXPIRATION:3600000}     # 1시간
   refresh-token-expiration: ${JWT_REFRESH_TOKEN_EXPIRATION:86400000}  # 1일
 
-# NHN Cloud Object Storage 설정
+# OCI Object Storage 설정 (S3 호환)
 s3:
   base-path: local/spots/

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -32,14 +32,13 @@ oauth2:
     redirect-uri: "http://localhost:8080/api/v1/auth/kakao/callback"
     app-id: 1234567890
 
-# S3 설정 (테스트용)
+# S3 설정 (테스트용 - OCI S3 호환 모드)
 s3:
   credentials:
     access-key: "test-access-key"
     secret-key: "test-secret-key"
   endpoint: "http://localhost:9000"
   storage-url: "http://localhost:9000"
-  tenant-id: "test-tenant-id"
   region:
     name: "kr-1"
   bucket: "test-bucket"

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -37,13 +37,12 @@ oauth2:
     redirect-uri: ${KAKAO_REDIRECT_URI}
     app-id: ${KAKAO_APP_ID}
 
-# NHN Cloud Object Storage 설정
+# OCI Object Storage 설정 (S3 호환)
 s3:
   credentials:
     access-key: ${S3_ACCESS_KEY}
     secret-key: ${S3_SECRET_KEY}
   endpoint: ${S3_ENDPOINT}
-  tenant-id: ${S3_TENANT_ID}
   region:
     name: ${S3_REGION}
   bucket: ${S3_BUCKET}


### PR DESCRIPTION
## 요약
NHN Cloud에서 Oracle Cloud Infrastructure(OCI)로 인프라 플랫폼 전체 이전

<br>

## 작업 내용
- **Object Storage 이전**: NHN Cloud Object Storage → OCI Object Storage (S3 호환 API)
    - S3Properties에서 tenantId 제거
    - URL 생성 로직을 OCI S3 호환 모드로 변경
    - 환경별 설정 파일 업데이트
- **데이터베이스 설정**: VM Docker Compose MySQL 연결 설정 변경
    - SSL 검증 비활성화 (내부 네트워크 사용)
    - 연결 설정 단순화
- **서버 배포 설정**: OCI VM 환경을 위한 서버 구성
    - Dockerfile JAVA_OPTS 추가
    - forward-headers-strategy 설정 추가
- **CI/CD 파이프라인**: GitHub Actions 워크플로우 재구성
    - NHN Cloud Pipeline 실행 제거
    - OCI VM SSH 자동 배포 워크플로우 추가

<br>

## 참고 사항

- OCI Object Storage는 S3 호환 API를 제공하여 기존 AWS SDK 재사용 가능
- Docker Compose로 구성된 MySQL은 VM 내부 네트워크에서 동작
- GitHub Actions의 workflow_run 트리거를 활용하여 CI 성공 시 자동 배포
- 모든 민감 정보는 GitHub Secrets로 관리

<br>

## 관련 이슈

- Refs #46