### PR TITLE
Fix(docker): Update base image to eclipse-temurin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17-jdk-slim
+FROM eclipse-temurin:17-jdk-jammy
 
 WORKDIR /app
 


### PR DESCRIPTION
## 요약
Docker 빌드 실패를 해결하기 위해 base image를 Eclipse Temurin으로 업데이트

## 작업 내용

- **Docker Base Image 변경**
    - `FROM openjdk:17-jdk-slim` → `FROM eclipse-temurin:17-jdk-jammy`
    - openjdk:17-jdk-slim 태그가 더 이상 유효하지 않아 발생한 이미지 pull 실패 해결
    - Eclipse Temurin은 Adoptium의 공식 OpenJDK 배포판 사용

<br>

## 참고 사항

- **문제 원인**: openjdk Docker 이미지가 deprecated되어 Docker Hub에서 더 이상 제공되지 않음
- **Eclipse Temurin**: Adoptium에서 제공하는 공식 OpenJDK 배포판
    - 장기 지원(LTS) 보장
    - 정기적인 보안 패치 및 업데이트 제공
    - Ubuntu 22.04 LTS(Jammy) 기반으로 안정성 확보
- **호환성**: OpenJDK 17 기반으로 기존 애플리케이션과 호환

<br>

## 관련 이슈
- Refs #46

<br>