### PR TITLE
Chore(config): Set default timezone to Asia/Seoul

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,6 @@ RUN ./gradlew clean build -x test --no-daemon
 
 EXPOSE 8080
 
-ENV JAVA_OPTS=""
+ENV JAVA_OPTS="-Duser.timezone=Asia/Seoul"
 
 CMD ["sh", "-c", "java $JAVA_OPTS -jar build/libs/gemmap-0.0.1-SNAPSHOT.jar"]

--- a/src/main/java/com/gemmap/gemmap/image/application/service/ExifExtractor.java
+++ b/src/main/java/com/gemmap/gemmap/image/application/service/ExifExtractor.java
@@ -51,7 +51,7 @@ public class ExifExtractor {
         return Optional.ofNullable(metadata.getFirstDirectoryOfType(ExifSubIFDDirectory.class))
                 .map(dir -> dir.getDate(ExifSubIFDDirectory.TAG_DATETIME_ORIGINAL))
                 .map(Date::toInstant)
-                .map(instant -> LocalDateTime.ofInstant(instant, java.time.ZoneOffset.UTC));
+                .map(instant -> LocalDateTime.ofInstant(instant, java.time.ZoneId.of("Asia/Seoul")));
     }
 
     private static Optional<com.drew.lang.GeoLocation> extractGps(Metadata metadata) {

--- a/src/main/java/com/gemmap/gemmap/spot/application/dto/response/SpotDetailResponse.java
+++ b/src/main/java/com/gemmap/gemmap/spot/application/dto/response/SpotDetailResponse.java
@@ -18,7 +18,7 @@ public record SpotDetailResponse(
         String alias,           // 스팟 별칭
         String fileUrl,         // 사진 URL
         String address,         // 도로명주소
-        String takenAt,         // 촬영시각(UTC, ISO-8601 Z)
+        String takenAt,         // 촬영시각(KST, ISO-8601)
         BigDecimal latitude,    // 위도
         BigDecimal longitude,   // 경도
         String cameraMake,      // 카메라 브랜드
@@ -27,7 +27,7 @@ public record SpotDetailResponse(
         String shutterSpeed,    // 셔터속도
         Integer iso,            // ISO
         BigDecimal focalLength, // 초점거리
-        String createdAt        // 생성시각(스팟, UTC, ISO-8601 Z)
+        String createdAt        // 생성시각(스팟, KST, ISO-8601)
 ) {
 
     public static SpotDetailResponse from (Spot spot, User spotOwner, SpotPhoto photo) {
@@ -38,7 +38,7 @@ public record SpotDetailResponse(
                 .alias(spot.getAlias())
                 .fileUrl(photo.getFileUrl())
                 .address(spot.getAddress())
-                .takenAt(toUtcIso(photo.getTakenAt())) // LocalDateTime/Instant/OffsetDateTime 대응
+                .takenAt(toKstIso(photo.getTakenAt())) // LocalDateTime/Instant/OffsetDateTime 대응
                 .latitude(photo.getLatitude())
                 .longitude(photo.getLongitude())
                 .cameraMake(photo.getCameraMake())
@@ -47,28 +47,28 @@ public record SpotDetailResponse(
                 .shutterSpeed(photo.getShutterSpeed())
                 .iso(photo.getIso())
                 .focalLength(photo.getFocalLength())
-                .createdAt(toUtcIso(spot.getCreatedAt()))
+                .createdAt(toKstIso(spot.getCreatedAt()))
                 .build();
     }
 
-    // 시간 포맷터 (UTC ISO_INSTANT)
-    private static String toUtcIso(Object temporal) {
+    // 시간 포맷터 (KST 기준)
+    private static String toKstIso(Object temporal) {
         if (temporal == null) return null;
-        Instant instant;
+        LocalDateTime localDateTime;
 
         if (temporal instanceof Instant i) {
-            instant = i;
+            localDateTime = LocalDateTime.ofInstant(i, ZoneId.of("Asia/Seoul"));
         } else if (temporal instanceof LocalDateTime ldt) {
-            instant = ldt.atZone(ZoneId.systemDefault()).toInstant();
+            localDateTime = ldt;
         } else if (temporal instanceof OffsetDateTime odt) {
-            instant = odt.toInstant();
+            localDateTime = odt.atZoneSameInstant(ZoneId.of("Asia/Seoul")).toLocalDateTime();
         } else if (temporal instanceof ZonedDateTime zdt) {
-            instant = zdt.toInstant();
+            localDateTime = zdt.withZoneSameInstant(ZoneId.of("Asia/Seoul")).toLocalDateTime();
         } else {
             throw new IllegalArgumentException("Unsupported temporal type: " + temporal.getClass());
         }
 
-        instant = instant.truncatedTo(ChronoUnit.SECONDS);
-        return DateTimeFormatter.ISO_INSTANT.format(instant); // ex) 2025-10-23T11:22:33Z
+        localDateTime = localDateTime.truncatedTo(ChronoUnit.SECONDS);
+        return DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(localDateTime); // ex) 2025-10-27T21:34:56
     }
 }

--- a/src/main/java/com/gemmap/gemmap/spot/application/service/SpotService.java
+++ b/src/main/java/com/gemmap/gemmap/spot/application/service/SpotService.java
@@ -135,7 +135,8 @@ public class SpotService {
     private static LocalDateTime parseUtc(String isoZ) {
         if (isoZ == null || isoZ.isBlank()) return null;
         try {
-            return LocalDateTime.ofInstant(Instant.parse(isoZ), ZoneOffset.UTC);
+            // UTC ISO8601 입력을 파싱하여 KST 시간으로 변환하여 저장
+            return LocalDateTime.ofInstant(Instant.parse(isoZ), java.time.ZoneId.of("Asia/Seoul"));
         } catch (DateTimeParseException e) {
             throw new CommonException(ErrorCode.INVALID_INPUT_VALUE, "takenAt은 UTC ISO8601 형식이어야 합니다.");
         }
@@ -146,7 +147,7 @@ public class SpotService {
             .filter(n -> n.contains("."))
             .map(n -> n.substring(n.lastIndexOf('.')))
             .orElse(".jpg");
-        String ym = DateTimeFormatter.ofPattern("yyyy/MM").format(LocalDate.now(ZoneOffset.UTC));
+        String ym = DateTimeFormatter.ofPattern("yyyy/MM").format(LocalDate.now(java.time.ZoneId.of("Asia/Seoul")));
         return basePath + ym + "/" + UUID.randomUUID() + ext;
     }
 

--- a/src/main/java/com/gemmap/gemmap/spot/domain/entity/SpotPhoto.java
+++ b/src/main/java/com/gemmap/gemmap/spot/domain/entity/SpotPhoto.java
@@ -37,7 +37,7 @@ public class SpotPhoto {
     private ESpotPhotoType type; // 업로드 목적
 
     @Column(name = "taken_at")
-    private LocalDateTime takenAt; // 촬영 시각 (UTC 저장)
+    private LocalDateTime takenAt; // 촬영 시각 (KST 저장)
 
     @Column(precision = 10, scale = 8, nullable = false)
     private BigDecimal latitude; // 위도

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,6 +5,8 @@ spring:
     multipart:
       max-file-size: 10MB
       max-request-size: 50MB
+  jackson:
+    time-zone: Asia/Seoul
 management:
   endpoints:
     web:


### PR DESCRIPTION
## 요약
애플리케이션의 기본 타임존을 UTC에서 KST(Asia/Seoul)로 변경하여 서버 내부 시간 처리의 일관성을 확보함.

<br>

## 작업 내용
- **JVM 기본 타임존 설정**: Dockerfile에서 `Duser.timezone=Asia/Seoul` 추가
- **Jackson 타임존 설정**: `application.yml`에서 `spring.jackson.time-zone: Asia/Seoul` 추가
- **EXIF 데이터 파싱**: EXIF 촬영 시각을 KST 기준으로 파싱 (`ExifExtractor.java`)
- **API 입력 처리**: UTC ISO8601 형식 입력을 KST로 변환하여 DB 저장 (`SpotService.java`)
- **API 응답 형식**: KST LocalDateTime 형식으로 통일 (`SpotDetailResponse.java`)
- **S3 키 생성**: 현재 날짜를 KST 기준으로 사용하여 경로 생성
- **주석 업데이트**: 실제 저장 방식(KST)을 반영하도록 코드 주석 수정

<br>

## 참고 사항

<br>

## 관련 이슈
- Closes #49

<br>