### PR TITLE
Refactor(timezone): KST 타임존 명시적 적용 및 촬영 시각 파싱 개선

### DIFF
--- a/src/main/java/com/gemmap/gemmap/GemmapApplication.java
+++ b/src/main/java/com/gemmap/gemmap/GemmapApplication.java
@@ -1,7 +1,10 @@
 package com.gemmap.gemmap;
 
+import jakarta.annotation.PostConstruct;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+import java.util.TimeZone;
 
 @SpringBootApplication
 public class GemmapApplication {
@@ -10,4 +13,9 @@ public class GemmapApplication {
 		SpringApplication.run(GemmapApplication.class, args);
 	}
 
+	@PostConstruct
+	public void init() {
+		// JVM 기본 타임존을 Asia/Seoul로 설정
+		TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
+	}
 }

--- a/src/main/java/com/gemmap/gemmap/auth/application/service/AuthService.java
+++ b/src/main/java/com/gemmap/gemmap/auth/application/service/AuthService.java
@@ -26,6 +26,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.Optional;
 import java.util.UUID;
@@ -43,6 +44,8 @@ import java.util.UUID;
 @Service
 @RequiredArgsConstructor
 public class AuthService {
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
 
     private final UserRepository userRepository;
     private final JwtUtil jwtUtil;
@@ -414,7 +417,7 @@ public class AuthService {
             extension = originalFilename.substring(originalFilename.lastIndexOf("."));
         }
 
-        LocalDate now = LocalDate.now();
+        LocalDate now = LocalDate.now(KST);
         String datePath = now.format(DateTimeFormatter.ofPattern("yyyy/MM"));
         String uuid = UUID.randomUUID().toString();
 

--- a/src/main/java/com/gemmap/gemmap/auth/domain/entity/User.java
+++ b/src/main/java/com/gemmap/gemmap/auth/domain/entity/User.java
@@ -13,6 +13,7 @@ import org.hibernate.annotations.DynamicUpdate;
 import org.hibernate.annotations.SQLDelete;
 
 import java.time.LocalDate;
+import java.time.ZoneId;
 
 /**
  * 사용자 엔티티
@@ -42,9 +43,11 @@ public class User {
     @Enumerated(EnumType.STRING)
     private ERole role;
 
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
     @Builder.Default
     @Column(name = "create_date", nullable = false)
-    private LocalDate createDate = LocalDate.now();
+    private LocalDate createDate = LocalDate.now(KST);
 
     @Column(name = "refresh_token")
     private String refreshToken;
@@ -93,7 +96,7 @@ public class User {
         this.socialId = socialId;
         this.eProvider = eProvider;
         this.role = role;
-        this.createDate = LocalDate.now();
+        this.createDate = LocalDate.now(KST);
         this.isLogin = false;
         this.isDeleted = false;
         this.email = email;
@@ -155,7 +158,7 @@ public class User {
 
     public void withdrawUser() {
         this.isDeleted = true;
-        this.deleteDate = LocalDate.now();
+        this.deleteDate = LocalDate.now(KST);
         this.refreshToken = null;
         this.isLogin = false;
     }

--- a/src/main/java/com/gemmap/gemmap/spot/application/service/SpotService.java
+++ b/src/main/java/com/gemmap/gemmap/spot/application/service/SpotService.java
@@ -23,9 +23,10 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.math.BigDecimal;
-import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
@@ -38,6 +39,8 @@ import java.util.stream.Collectors;
 @Service
 @RequiredArgsConstructor
 public class SpotService {
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
 
     private final SpotRepository spotRepository;
     private final UserRepository userRepository;
@@ -97,7 +100,7 @@ public class SpotService {
                 .user(user)
                 .fileUrl(fileUrl)
                 .type(ESpotPhotoType.SPOT)
-                .takenAt(parseUtc(req.takenAt()))
+                .takenAt(parseTakenAt(req.takenAt()))
                 .latitude(req.latitude())
                 .longitude(req.longitude())
                 .cameraMake(req.cameraMake())
@@ -132,14 +135,79 @@ public class SpotService {
         }
     }
 
-    private static LocalDateTime parseUtc(String isoZ) {
-        if (isoZ == null || isoZ.isBlank()) return null;
+    /**
+     * 촬영 시각 문자열을 LocalDateTime(KST)으로 파싱
+     *
+     * <p>타임존 오프셋이 포함된 ISO 8601 형식을 권장합니다.</p>
+     *
+     * <h3>지원 형식 (우선순위 순):</h3>
+     * <ol>
+     *   <li><b>오프셋 포함 (권장)</b>: "2025-11-01T14:51:24+09:00" → KST 변환하여 저장</li>
+     *   <li><b>UTC (Z suffix)</b>: "2025-11-01T05:51:24Z" → KST 변환하여 저장 (+9시간)</li>
+     *   <li><b>오프셋 없음 (Fallback)</b>: "2025-11-01T14:51:24" → KST로 가정하여 저장</li>
+     * </ol>
+     *
+     * <h3>클라이언트 구현 가이드:</h3>
+     * <ul>
+     *   <li>EXIF 촬영 시각 추출 시, 가능하면 OffsetTimeOriginal 태그를 함께 확인하세요.</li>
+     *   <li>타임존 정보가 있으면 ISO 8601 오프셋 형식으로 전송하세요. (예: +09:00, +01:00)</li>
+     *   <li>타임존 정보가 없으면 로컬 시간 그대로 전송하세요. (서버에서 KST로 가정 처리)</li>
+     * </ul>
+     *
+     * <h3>변환 예시:</h3>
+     * <pre>
+     * 입력: "2025-11-01T10:00:00+01:00" (파리, UTC+1)
+     * 절대 시간: 2025-11-01T09:00:00Z (UTC)
+     * KST 변환: 2025-11-01T18:00:00 (UTC+9)
+     * DB 저장: 2025-11-01 18:00:00
+     * </pre>
+     *
+     * @param takenAt ISO 8601 형식의 촬영 시각 문자열 (null 허용)
+     * @return KST 기준 LocalDateTime, 입력이 null/blank이면 null
+     * @throws CommonException takenAt 형식이 올바르지 않은 경우
+     */
+    private static LocalDateTime parseTakenAt(String takenAt) {
+        if (takenAt == null || takenAt.isBlank()) return null;
+
         try {
-            // UTC ISO8601 입력을 파싱하여 KST 시간으로 변환하여 저장
-            return LocalDateTime.ofInstant(Instant.parse(isoZ), java.time.ZoneId.of("Asia/Seoul"));
+            // 1. 타임존/오프셋 정보가 포함된 경우: OffsetDateTime으로 파싱 후 KST 변환
+            if (hasTimezoneInfo(takenAt)) {
+                OffsetDateTime odt = OffsetDateTime.parse(takenAt, DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+                // 절대 시간(Instant)은 유지하고 표기만 KST로 변환
+                return odt.atZoneSameInstant(KST).toLocalDateTime();
+            }
+
+            // 2. 타임존 정보가 없는 경우 (Fallback): KST로 가정하여 처리
+            // 주의: 해외에서 촬영한 사진의 경우 실제 시간과 다를 수 있음
+            log.debug("takenAt에 타임존 정보 없음. KST로 가정하여 처리: {}", takenAt);
+            return LocalDateTime.parse(takenAt, DateTimeFormatter.ISO_LOCAL_DATE_TIME);
+
         } catch (DateTimeParseException e) {
-            throw new CommonException(ErrorCode.INVALID_INPUT_VALUE, "takenAt은 UTC ISO8601 형식이어야 합니다.");
+            throw new CommonException(ErrorCode.INVALID_INPUT_VALUE,
+                "takenAt 형식이 올바르지 않습니다. ISO 8601 형식을 사용하세요. " +
+                "(권장: 2025-11-01T14:51:24+09:00, 허용: 2025-11-01T14:51:24Z, 2025-11-01T14:51:24)");
         }
+    }
+
+    /**
+     * 문자열에 타임존/오프셋 정보가 포함되어 있는지 확인
+     *
+     * @param dateTimeStr ISO 8601 형식의 날짜/시간 문자열
+     * @return 타임존 정보 포함 여부
+     */
+    private static boolean hasTimezoneInfo(String dateTimeStr) {
+        // Z (UTC), + (양수 오프셋), 또는 T 이후의 - (음수 오프셋) 확인
+        // 예: 2025-11-01T14:51:24Z, 2025-11-01T14:51:24+09:00, 2025-11-01T14:51:24-05:00
+        if (dateTimeStr.endsWith("Z")) return true;
+        if (dateTimeStr.contains("+")) return true;
+
+        // T 이후에 -가 있으면 오프셋 (날짜 부분의 -와 구분)
+        int tIndex = dateTimeStr.indexOf('T');
+        if (tIndex > 0) {
+            String timePart = dateTimeStr.substring(tIndex);
+            return timePart.contains("-");
+        }
+        return false;
     }
 
     private String buildSpotKey(String originalName) {
@@ -147,7 +215,7 @@ public class SpotService {
             .filter(n -> n.contains("."))
             .map(n -> n.substring(n.lastIndexOf('.')))
             .orElse(".jpg");
-        String ym = DateTimeFormatter.ofPattern("yyyy/MM").format(LocalDate.now(java.time.ZoneId.of("Asia/Seoul")));
+        String ym = DateTimeFormatter.ofPattern("yyyy/MM").format(LocalDate.now(KST));
         return basePath + ym + "/" + UUID.randomUUID() + ext;
     }
 


### PR DESCRIPTION
## 요약
애플리케이션 전체에 KST(Asia/Seoul) 타임존을 명시적으로 적용하고, 촬영 시각(takenAt) 파싱 로직을 리팩토링하여 다양한 타임존 오프셋을 지원한다.

<br>

## 작업 내용
1. JVM 타임존 설정
  - `GemmapApplication.java`에 `@PostConstruct`로 JVM 기본 타임존을 Asia/Seoul로 설정
  - `LocalDateTime.now()`, `@CreationTimestamp` 등이 기본적으로 KST 사용

2. 코드 레벨 명시적 KST 적용
  - `User.java`: KST 상수 추가, `LocalDate.now(KST)` 적용 (createDate, deleteDate)
  - `AuthService.java`: KST 상수 추가, 프로필 이미지 경로 생성 시 `LocalDate.now(KST)` 사용

3. 촬영 시각 파싱 리팩토링 (SpotService)
  - `parseUtc()` → `parseTakenAt()`으로 메서드명 변경
  - `Instant.parse()` → `OffsetDateTime.parse()`로 변경하여 다양한 오프셋 지원
  - `atZoneSameInstant(KST)` 사용하여 절대 시간 유지하면서 KST로 변환
  - `hasTimezoneInfo()` 헬퍼 메서드 추가
  - 타임존 정보 없는 입력에 대한 Fallback 처리 (KST로 가정)

4. 지원 형식

| 우선순위 | 형식 | 예시 | 처리 방식 |
|---------|------|------|----------|
| 1 (권장) | 오프셋 포함 | `2025-11-01T14:51:24+09:00` | KST로 변환 |
| 2 | UTC (Z) | `2025-11-01T05:51:24Z` | KST로 변환 (+9시간) |
| 3 (Fallback) | 오프셋 없음 | `2025-11-01T14:51:24` | KST로 가정 |

<br>

## 참고 사항
- 기존 `Instant.parse()`는 `Z`로 끝나는 UTC 문자열만 지원했으나, 리팩토링 후 `+09:00`, `-05:00` 등 다양한 오프셋 지원

<br>

## 관련 이슈
- Refs #49 

<br>