### PR TITLE
Refactor(spot): Spot 주소 구조를 단일 필드에서 컴포넌트 기반으로 변경

### DIFF
--- a/src/main/java/com/gemmap/gemmap/spot/application/dto/request/SpotCreateRequest.java
+++ b/src/main/java/com/gemmap/gemmap/spot/application/dto/request/SpotCreateRequest.java
@@ -4,7 +4,12 @@ import java.math.BigDecimal;
 
 public record SpotCreateRequest(
     String alias,
-    String address,
+    String sido,
+    String sigungu,
+    String eupmyeondong,
+    String roadName,
+    String buildingNo,
+    String fullAddress,
     String takenAt,
     BigDecimal latitude,
     BigDecimal longitude,

--- a/src/main/java/com/gemmap/gemmap/spot/application/dto/response/SpotDetailResponse.java
+++ b/src/main/java/com/gemmap/gemmap/spot/application/dto/response/SpotDetailResponse.java
@@ -17,7 +17,7 @@ public record SpotDetailResponse(
         String nickname,        // 사용자 닉네임
         String alias,           // 스팟 별칭
         String fileUrl,         // 사진 URL
-        String address,         // 도로명주소
+        String address,         // 전체 주소
         String takenAt,         // 촬영시각(KST, ISO-8601)
         BigDecimal latitude,    // 위도
         BigDecimal longitude,   // 경도
@@ -37,7 +37,7 @@ public record SpotDetailResponse(
                 .nickname(spotOwner.getNickname())
                 .alias(spot.getAlias())
                 .fileUrl(photo.getFileUrl())
-                .address(spot.getAddress())
+                .address(spot.getFullAddress())
                 .takenAt(toKstIso(photo.getTakenAt())) // LocalDateTime/Instant/OffsetDateTime 대응
                 .latitude(photo.getLatitude())
                 .longitude(photo.getLongitude())

--- a/src/main/java/com/gemmap/gemmap/spot/application/dto/response/SpotSummary.java
+++ b/src/main/java/com/gemmap/gemmap/spot/application/dto/response/SpotSummary.java
@@ -11,14 +11,14 @@ public record SpotSummary(
         Long spotId,       // 스팟 ID
         String fileUrl,    // 사진 URL
         String alias,      // 스팟 별칭
-        String address     // 도로명주소
+        String address     // 단축 주소
 ) {
     public static SpotSummary of(Spot spot, String fileUrl) {
         return SpotSummary.builder()
                 .spotId(spot.getId())
                 .fileUrl(fileUrl)
                 .alias(spot.getAlias())
-                .address(spot.getAddress())
+                .address(spot.getShortAddress())
                 .build();
     }
 }

--- a/src/main/java/com/gemmap/gemmap/spot/application/service/SpotService.java
+++ b/src/main/java/com/gemmap/gemmap/spot/application/service/SpotService.java
@@ -27,7 +27,6 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
-import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.List;
@@ -89,7 +88,13 @@ public class SpotService {
             Spot spot = spotRepository.save(
                 Spot.builder()
                     .user(user)
-                    .address(req.address())
+                    .sido(req.sido())
+                    .sigungu(req.sigungu())
+                    .eupmyeondong(req.eupmyeondong())
+                    .roadName(req.roadName())
+                    .buildingNo(req.buildingNo())
+                    .fullAddress(req.fullAddress())
+                    .shortAddress(req.sido() + " " + req.sigungu()) // 예: 경기도 남양주시 (리스트 화면용)
                     .alias(req.alias())
                     .build()
             );

--- a/src/main/java/com/gemmap/gemmap/spot/domain/entity/Spot.java
+++ b/src/main/java/com/gemmap/gemmap/spot/domain/entity/Spot.java
@@ -10,7 +10,6 @@ import java.time.LocalDateTime;
 @Entity
 @Table(name = "spots")
 @Getter
-@Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class Spot {
@@ -23,8 +22,26 @@ public class Spot {
     @JoinColumn(name = "user_id", nullable = false)
     private User user; // 생성자 (사용자 id)
 
-    @Column(length = 400, nullable = false)
-    private String address; // 도로명주소
+    @Column(length = 20, nullable = false)
+    private String sido; // 시/도 - 예: 경기도, 서울특별시
+
+    @Column(length = 20, nullable = false)
+    private String sigungu; // 시/군/구 - 예: 남앙주시, 강남구
+
+    @Column(length = 20)
+    private String eupmyeondong; // 읍/면/동 = 예: 와부읍, 삼성동
+
+    @Column(length = 100)
+    private String roadName; // 도로명 - 예: 경걍로926번길
+
+    @Column(length = 20)
+    private String buildingNo; // 건물번호 - 예: 20
+
+    @Column(length = 255, nullable = false)
+    private String fullAddress; // 전체 주소 - 예: 대한민국 경기도 남양주시 와부읍... (상세 화면용)
+
+    @Column(length = 50, nullable = false)
+    private String shortAddress; // 단축 주소 - 예: 경기도 남양주시 (리스트 화면용)
 
     @Column(length = 200, nullable = false)
     private String alias; // 별칭 - 사용자 입력
@@ -32,4 +49,20 @@ public class Spot {
     @CreationTimestamp
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt; // 생성 시각
+
+    @Builder
+    public Spot(User user,
+                String sido, String sigungu, String eupmyeondong, String roadName, String buildingNo,
+                String fullAddress, String shortAddress,
+                String alias, LocalDateTime createdAt) {
+        this.user = user;
+        this.sido = sido;
+        this.sigungu = sigungu;
+        this.eupmyeondong = eupmyeondong;
+        this.roadName = roadName;
+        this.buildingNo = buildingNo;
+        this.fullAddress = fullAddress;
+        this.shortAddress = shortAddress;
+        this.alias = alias;
+    }
 }

--- a/src/main/java/com/gemmap/gemmap/spot/presentation/SpotController.java
+++ b/src/main/java/com/gemmap/gemmap/spot/presentation/SpotController.java
@@ -43,22 +43,29 @@ public class SpotController {
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseDto<SpotCreateResponse> create(
             @UserId Long userId,
-            @RequestParam(value = "file") MultipartFile file,
-            @RequestParam(value = "alias") String alias,
-            @RequestParam(value = "address") String address,
-            @RequestParam(value = "takenAt", required = false) String takenAt,
-            @RequestParam(value = "latitude") BigDecimal latitude,
-            @RequestParam(value = "longitude") BigDecimal longitude,
-            @RequestParam(value = "cameraMake", required = false) String cameraMake,
-            @RequestParam(value = "cameraModel", required = false) String cameraModel,
-            @RequestParam(value = "aperture", required = false) BigDecimal aperture,
-            @RequestParam(value = "shutterSpeed", required = false) String shutterSpeed,
-            @RequestParam(value = "iso", required = false) Integer iso,
-            @RequestParam(value = "focalLength", required = false) BigDecimal focalLength
+            @RequestParam MultipartFile file,
+            @RequestParam String alias,
+            // 주소 관련 파라미터
+            @RequestParam String sido,
+            @RequestParam String sigungu,
+            @RequestParam(required = false) String eupmyeondong,
+            @RequestParam(required = false) String roadName,
+            @RequestParam(required = false) String buildingNo,
+            @RequestParam String fullAddress,
+            // 기타 파라미터
+            @RequestParam(required = false) String takenAt,
+            @RequestParam BigDecimal latitude,
+            @RequestParam BigDecimal longitude,
+            @RequestParam(required = false) String cameraMake,
+            @RequestParam(required = false) String cameraModel,
+            @RequestParam(required = false) BigDecimal aperture,
+            @RequestParam(required = false) String shutterSpeed,
+            @RequestParam(required = false) Integer iso,
+            @RequestParam(required = false) BigDecimal focalLength
     ) {
         SpotCreateRequest request = new SpotCreateRequest(
-            alias, address, takenAt, latitude, longitude,
-            cameraMake, cameraModel, aperture, shutterSpeed, iso, focalLength
+            alias, sido, sigungu, eupmyeondong, roadName, buildingNo, fullAddress,
+            takenAt, latitude, longitude, cameraMake, cameraModel, aperture, shutterSpeed, iso, focalLength
         );
         return ResponseDto.created(spotService.create(userId, request, file));
     }
@@ -73,7 +80,7 @@ public class SpotController {
     @DeleteMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseDto<?> delete(
             @UserId Long userId,
-            @RequestParam(value = "spotId") Long spotId
+            @RequestParam Long spotId
     ) {
         spotService.delete(userId, spotId);
         return ResponseDto.noContent();

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -1,6 +1,6 @@
 spring:
   datasource:
-    url: jdbc:h2:mem:testdb
+    url: jdbc:h2:mem:testdb;MODE=MySQL
     username: sa
     password: password
     driver-class-name: org.h2.Driver

--- a/src/test/java/com/gemmap/gemmap/spot/application/service/SpotServiceTest.java
+++ b/src/test/java/com/gemmap/gemmap/spot/application/service/SpotServiceTest.java
@@ -1,5 +1,7 @@
 package com.gemmap.gemmap.spot.application.service;
 
+import com.gemmap.gemmap.auth.domain.entity.User;
+import com.gemmap.gemmap.auth.domain.repository.UserRepository;
 import com.gemmap.gemmap.image.infrastructure.objectstorage.ObjectStorageService;
 import com.gemmap.gemmap.image.infrastructure.objectstorage.S3UrlGenerator;
 import com.gemmap.gemmap.shared.config.s3.S3Properties;
@@ -8,19 +10,24 @@ import com.gemmap.gemmap.shared.exception.ErrorCode;
 import com.gemmap.gemmap.spot.application.dto.request.SpotCreateRequest;
 import com.gemmap.gemmap.spot.application.support.SpotFileValidator;
 import com.gemmap.gemmap.spot.domain.entity.Spot;
+import com.gemmap.gemmap.spot.domain.entity.SpotPhoto;
 import com.gemmap.gemmap.spot.domain.repository.SpotPhotoRepository;
 import com.gemmap.gemmap.spot.domain.repository.SpotRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.web.MockMultipartFile;
 
 import java.math.BigDecimal;
+import java.util.Optional;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
@@ -28,13 +35,16 @@ import static org.mockito.Mockito.*;
 
 /**
  * SpotService 단위 테스트
- * - 보상 트랜잭션 (DB 실패 시 S3 삭제)
+ * - 주소 필드 저장 검증
  */
 @ExtendWith(MockitoExtension.class)
 class SpotServiceTest {
 
     @Mock
     private SpotRepository spotRepository;
+
+    @Mock
+    private UserRepository userRepository;
 
     @Mock
     private SpotPhotoRepository spotPhotoRepository;
@@ -58,232 +68,173 @@ class SpotServiceTest {
     private static final String TEST_BUCKET = "test-bucket";
     private static final String TEST_FILE_URL = "https://test.com/spots/2025/10/uuid.jpg";
 
+    private User testUser;
+    private MockMultipartFile testFile;
+
     @BeforeEach
     void setUp() {
         // S3Properties Mock 설정 (lenient: 호출되지 않을 수 있음)
         lenient().when(s3Properties.getBucket()).thenReturn(TEST_BUCKET);
-    }
 
-    @Test
-    @DisplayName("보상 트랜잭션: DB 저장 실패 시 S3 객체 삭제 호출")
-    void create_whenDatabaseFailure_thenDeleteS3Object() throws Exception {
-        // Given: 유효한 파일 + DB 저장 실패 시나리오
+        // 테스트용 User Mock
+        testUser = mock(User.class);
+        lenient().when(testUser.getId()).thenReturn(TEST_USER_ID);
+
+        // 테스트용 JPEG 파일
         byte[] jpegSignature = {(byte) 0xFF, (byte) 0xD8, (byte) 0xFF, (byte) 0xE0};
-        MockMultipartFile file = new MockMultipartFile(
+        testFile = new MockMultipartFile(
             "file", "photo.jpg", "image/jpeg", jpegSignature
         );
+    }
 
-        SpotCreateRequest request = new SpotCreateRequest(
-            "테스트 스팟",
-            "서울특별시",
-            null,
-            BigDecimal.valueOf(37.5),
-            BigDecimal.valueOf(127.0),
-            null, null, null, null, null, null
+    private SpotCreateRequest createRequest(String alias, String sido, String sigungu,
+                                            String fullAddress, BigDecimal lat, BigDecimal lon) {
+        return new SpotCreateRequest(
+            alias, sido, sigungu, null, null, null, fullAddress,
+            null, lat, lon, null, null, null, null, null, null
         );
+    }
 
-        // SpotFileValidator는 통과
-        doNothing().when(spotFileValidator).validateImage(file);
+    private void mockUserFound() {
+        given(userRepository.findById(TEST_USER_ID)).willReturn(Optional.of(testUser));
+    }
 
-        // S3 업로드 성공
-        doNothing().when(objectStorageService).upload(eq(TEST_BUCKET), anyString(), eq(file));
+    private void mockS3UploadSuccess() throws Exception {
+        doNothing().when(objectStorageService).upload(eq(TEST_BUCKET), anyString(), any());
         given(s3UrlGenerator.generateUrl(anyString())).willReturn(TEST_FILE_URL);
-
-        // SpotRepository.save() 실패 (RuntimeException)
-        given(spotRepository.save(any(Spot.class)))
-            .willThrow(new RuntimeException("Database connection failed"));
-
-        // When & Then: DB 실패로 예외 발생
-        assertThatThrownBy(() -> spotService.create(TEST_USER_ID, request, file))
-            .isInstanceOf(RuntimeException.class)
-            .hasMessage("Database connection failed");
-
-        // Verify: S3 delete() 호출됨 (보상 트랜잭션)
-        verify(objectStorageService, times(1))
-            .delete(eq(TEST_BUCKET), anyString());
     }
 
-    @Test
-    @DisplayName("보상 트랜잭션: SpotPhoto 저장 실패 시 S3 객체 삭제 호출")
-    void create_whenSpotPhotoSaveFailure_thenDeleteS3Object() throws Exception {
-        // Given: Spot은 성공, SpotPhoto 저장 실패
-        byte[] jpegSignature = {(byte) 0xFF, (byte) 0xD8, (byte) 0xFF, (byte) 0xE0};
-        MockMultipartFile file = new MockMultipartFile(
-            "file", "photo.jpg", "image/jpeg", jpegSignature
-        );
+    // =====================================================================
+    // 주소 필드 저장 검증
+    // =====================================================================
 
-        SpotCreateRequest request = new SpotCreateRequest(
-            "테스트 스팟",
-            "서울특별시",
-            null,
-            BigDecimal.valueOf(37.5),
-            BigDecimal.valueOf(127.0),
-            null, null, null, null, null, null
-        );
+    @Nested
+    @DisplayName("주소 필드 저장 검증")
+    class AddressFieldTests {
 
-        // 검증 통과
-        doNothing().when(spotFileValidator).validateImage(file);
+        @Test
+        @DisplayName("스팟 생성 시 shortAddress 자동 생성 (sido + \" \" + sigungu)")
+        void create_shouldGenerateShortAddress() throws Exception {
+            // Given
+            mockUserFound();
+            doNothing().when(spotFileValidator).validateImage(testFile);
+            mockS3UploadSuccess();
 
-        // S3 업로드 성공
-        doNothing().when(objectStorageService).upload(eq(TEST_BUCKET), anyString(), eq(file));
-        given(s3UrlGenerator.generateUrl(anyString())).willReturn(TEST_FILE_URL);
+            SpotCreateRequest request = createRequest(
+                "자연광맛집", "경기도", "남양주시",
+                "대한민국 경기도 남양주시 와부읍 경강로926번길 20",
+                BigDecimal.valueOf(37.5), BigDecimal.valueOf(127.0)
+            );
 
-        // Spot 저장 성공
-        Spot savedSpot = Spot.builder()
-            .userId(TEST_USER_ID)
-            .alias("테스트 스팟")
-            .address("서울특별시")
-            .build();
-        given(spotRepository.save(any(Spot.class))).willReturn(savedSpot);
+            ArgumentCaptor<Spot> spotCaptor = ArgumentCaptor.forClass(Spot.class);
+            Spot savedSpot = Spot.builder()
+                .user(testUser)
+                .sido("경기도").sigungu("남양주시")
+                .fullAddress("대한민국 경기도 남양주시 와부읍 경강로926번길 20")
+                .shortAddress("경기도 남양주시")
+                .alias("자연광맛집")
+                .build();
+            given(spotRepository.save(spotCaptor.capture())).willReturn(savedSpot);
+            given(spotPhotoRepository.save(any(SpotPhoto.class))).willReturn(mock(SpotPhoto.class));
 
-        // SpotPhoto 저장 실패
-        given(spotPhotoRepository.save(any()))
-            .willThrow(new RuntimeException("Photo save failed"));
+            // When
+            spotService.create(TEST_USER_ID, request, testFile);
 
-        // When & Then: SpotPhoto 저장 실패로 예외 발생
-        assertThatThrownBy(() -> spotService.create(TEST_USER_ID, request, file))
-            .isInstanceOf(RuntimeException.class)
-            .hasMessage("Photo save failed");
+            // Then: shortAddress가 "경기도 남양주시"로 자동 생성됨
+            Spot capturedSpot = spotCaptor.getValue();
+            assertThat(capturedSpot.getShortAddress()).isEqualTo("경기도 남양주시");
+        }
 
-        // Verify: S3 delete() 호출됨
-        verify(objectStorageService, times(1))
-            .delete(eq(TEST_BUCKET), anyString());
+        @Test
+        @DisplayName("스팟 생성 시 주소 필드 전체 저장 검증")
+        void create_shouldSaveAllAddressFields() throws Exception {
+            // Given
+            mockUserFound();
+            doNothing().when(spotFileValidator).validateImage(testFile);
+            mockS3UploadSuccess();
+
+            SpotCreateRequest request = new SpotCreateRequest(
+                "테스트스팟", "서울특별시", "강남구", "삼성동", "테헤란로", "123",
+                "대한민국 서울특별시 강남구 삼성동 테헤란로 123",
+                null, BigDecimal.valueOf(37.5), BigDecimal.valueOf(127.0),
+                null, null, null, null, null, null
+            );
+
+            ArgumentCaptor<Spot> spotCaptor = ArgumentCaptor.forClass(Spot.class);
+            Spot savedSpot = Spot.builder()
+                .user(testUser)
+                .sido("서울특별시").sigungu("강남구").eupmyeondong("삼성동")
+                .roadName("테헤란로").buildingNo("123")
+                .fullAddress("대한민국 서울특별시 강남구 삼성동 테헤란로 123")
+                .shortAddress("서울특별시 강남구")
+                .alias("테스트스팟")
+                .build();
+            given(spotRepository.save(spotCaptor.capture())).willReturn(savedSpot);
+            given(spotPhotoRepository.save(any(SpotPhoto.class))).willReturn(mock(SpotPhoto.class));
+
+            // When
+            spotService.create(TEST_USER_ID, request, testFile);
+
+            // Then: 모든 주소 필드가 정확히 저장됨
+            Spot capturedSpot = spotCaptor.getValue();
+            assertThat(capturedSpot.getSido()).isEqualTo("서울특별시");
+            assertThat(capturedSpot.getSigungu()).isEqualTo("강남구");
+            assertThat(capturedSpot.getEupmyeondong()).isEqualTo("삼성동");
+            assertThat(capturedSpot.getRoadName()).isEqualTo("테헤란로");
+            assertThat(capturedSpot.getBuildingNo()).isEqualTo("123");
+            assertThat(capturedSpot.getFullAddress()).isEqualTo("대한민국 서울특별시 강남구 삼성동 테헤란로 123");
+            assertThat(capturedSpot.getShortAddress()).isEqualTo("서울특별시 강남구");
+        }
     }
 
-    @Test
-    @DisplayName("실패: S3 업로드 실패 시 FILE_UPLOAD_FAILED 예외")
-    void create_whenS3UploadFailure_thenThrowFileUploadFailed() throws Exception {
-        // Given: S3 업로드 실패
-        byte[] jpegSignature = {(byte) 0xFF, (byte) 0xD8, (byte) 0xFF, (byte) 0xE0};
-        MockMultipartFile file = new MockMultipartFile(
-            "file", "photo.jpg", "image/jpeg", jpegSignature
-        );
+    // =====================================================================
+    // 좌표 검증 테스트
+    // =====================================================================
 
-        SpotCreateRequest request = new SpotCreateRequest(
-            "테스트 스팟",
-            "서울특별시",
-            null,
-            BigDecimal.valueOf(37.5),
-            BigDecimal.valueOf(127.0),
-            null, null, null, null, null, null
-        );
+    @Nested
+    @DisplayName("좌표 범위 검증")
+    class CoordinateValidationTests {
 
-        // 검증 통과
-        doNothing().when(spotFileValidator).validateImage(file);
+        @Test
+        @DisplayName("위도 범위 초과 → INVALID_INPUT_VALUE 예외")
+        void create_whenInvalidLatitude_thenThrowInvalidInputValue() {
+            // Given
+            mockUserFound();
 
-        // S3 업로드 실패
-        doThrow(new RuntimeException("S3 connection timeout"))
-            .when(objectStorageService).upload(eq(TEST_BUCKET), anyString(), eq(file));
+            SpotCreateRequest request = createRequest(
+                "테스트 스팟", "서울특별시", "강남구",
+                "서울특별시 강남구", BigDecimal.valueOf(999.0), BigDecimal.valueOf(127.0)
+            );
 
-        // When & Then: FILE_UPLOAD_FAILED 예외 발생
-        assertThatThrownBy(() -> spotService.create(TEST_USER_ID, request, file))
-            .isInstanceOf(CommonException.class)
-            .hasFieldOrPropertyWithValue("errorCode", ErrorCode.FILE_UPLOAD_FAILED);
+            // When & Then
+            assertThatThrownBy(() -> spotService.create(TEST_USER_ID, request, testFile))
+                .isInstanceOf(CommonException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_INPUT_VALUE)
+                .hasMessageContaining("위도는 -90~90 범위여야 합니다");
 
-        // Verify: DB 저장 시도 안 함
-        verify(spotRepository, never()).save(any(Spot.class));
+            verify(spotFileValidator, never()).validateImage(any());
+            verify(objectStorageService, never()).upload(anyString(), anyString(), any());
+        }
 
-        // Verify: 보상 트랜잭션도 호출 안 됨 (업로드 자체가 실패했으므로)
-        verify(objectStorageService, never()).delete(anyString(), anyString());
-    }
+        @Test
+        @DisplayName("경도 범위 초과 → INVALID_INPUT_VALUE 예외")
+        void create_whenInvalidLongitude_thenThrowInvalidInputValue() {
+            // Given
+            mockUserFound();
 
-    @Test
-    @DisplayName("실패: 위도 범위 초과 → INVALID_INPUT_VALUE 예외")
-    void create_whenInvalidLatitude_thenThrowInvalidInputValue() throws Exception {
-        // Given: 잘못된 위도
-        byte[] jpegSignature = {(byte) 0xFF, (byte) 0xD8, (byte) 0xFF, (byte) 0xE0};
-        MockMultipartFile file = new MockMultipartFile(
-            "file", "photo.jpg", "image/jpeg", jpegSignature
-        );
+            SpotCreateRequest request = createRequest(
+                "테스트 스팟", "서울특별시", "강남구",
+                "서울특별시 강남구", BigDecimal.valueOf(37.5), BigDecimal.valueOf(-200.0)
+            );
 
-        SpotCreateRequest request = new SpotCreateRequest(
-            "테스트 스팟",
-            "서울특별시",
-            null,
-            BigDecimal.valueOf(999.0), // 유효 범위 초과
-            BigDecimal.valueOf(127.0),
-            null, null, null, null, null, null
-        );
+            // When & Then
+            assertThatThrownBy(() -> spotService.create(TEST_USER_ID, request, testFile))
+                .isInstanceOf(CommonException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_INPUT_VALUE)
+                .hasMessageContaining("경도는 -180~180 범위여야 합니다");
 
-        // When & Then: INVALID_INPUT_VALUE 예외 (위도 범위 검증 실패)
-        assertThatThrownBy(() -> spotService.create(TEST_USER_ID, request, file))
-            .isInstanceOf(CommonException.class)
-            .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_INPUT_VALUE)
-            .hasMessageContaining("위도는 -90~90 범위여야 합니다");
-
-        // Verify: 좌표 검증이 먼저 실패하므로 파일 검증, S3 업로드 시도 안 함
-        verify(spotFileValidator, never()).validateImage(any());
-        verify(objectStorageService, never()).upload(anyString(), anyString(), any());
-    }
-
-    @Test
-    @DisplayName("실패: 경도 범위 초과 → INVALID_INPUT_VALUE 예외")
-    void create_whenInvalidLongitude_thenThrowInvalidInputValue() throws Exception {
-        // Given: 잘못된 경도
-        byte[] jpegSignature = {(byte) 0xFF, (byte) 0xD8, (byte) 0xFF, (byte) 0xE0};
-        MockMultipartFile file = new MockMultipartFile(
-            "file", "photo.jpg", "image/jpeg", jpegSignature
-        );
-
-        SpotCreateRequest request = new SpotCreateRequest(
-            "테스트 스팟",
-            "서울특별시",
-            null,
-            BigDecimal.valueOf(37.5),
-            BigDecimal.valueOf(-200.0), // 유효 범위 초과
-            null, null, null, null, null, null
-        );
-
-        // When & Then: INVALID_INPUT_VALUE 예외 (경도 범위 검증 실패)
-        assertThatThrownBy(() -> spotService.create(TEST_USER_ID, request, file))
-            .isInstanceOf(CommonException.class)
-            .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_INPUT_VALUE)
-            .hasMessageContaining("경도는 -180~180 범위여야 합니다");
-
-        // Verify: 좌표 검증이 먼저 실패하므로 파일 검증, S3 업로드 시도 안 함
-        verify(spotFileValidator, never()).validateImage(any());
-        verify(objectStorageService, never()).upload(anyString(), anyString(), any());
-    }
-
-    @Test
-    @DisplayName("보상 트랜잭션: S3 삭제 실패해도 원래 예외 전파")
-    void create_whenDbFailureAndS3DeleteFailure_thenPropagateOriginalException() throws Exception {
-        // Given: DB 실패 + S3 삭제도 실패
-        byte[] jpegSignature = {(byte) 0xFF, (byte) 0xD8, (byte) 0xFF, (byte) 0xE0};
-        MockMultipartFile file = new MockMultipartFile(
-            "file", "photo.jpg", "image/jpeg", jpegSignature
-        );
-
-        SpotCreateRequest request = new SpotCreateRequest(
-            "테스트 스팟",
-            "서울특별시",
-            null,
-            BigDecimal.valueOf(37.5),
-            BigDecimal.valueOf(127.0),
-            null, null, null, null, null, null
-        );
-
-        // 검증 통과
-        doNothing().when(spotFileValidator).validateImage(file);
-
-        // S3 업로드 성공
-        doNothing().when(objectStorageService).upload(eq(TEST_BUCKET), anyString(), eq(file));
-        given(s3UrlGenerator.generateUrl(anyString())).willReturn(TEST_FILE_URL);
-
-        // DB 저장 실패
-        RuntimeException originalException = new RuntimeException("Database connection failed");
-        given(spotRepository.save(any(Spot.class))).willThrow(originalException);
-
-        // S3 삭제도 실패 (보상 트랜잭션 실패)
-        doThrow(new RuntimeException("S3 delete failed"))
-            .when(objectStorageService).delete(anyString(), anyString());
-
-        // When & Then: 원래 예외(DB 실패)가 전파되어야 함
-        assertThatThrownBy(() -> spotService.create(TEST_USER_ID, request, file))
-            .isInstanceOf(RuntimeException.class)
-            .hasMessage("Database connection failed"); // S3 삭제 실패가 아닌 원래 예외
-
-        // Verify: S3 삭제 시도는 함
-        verify(objectStorageService, times(1)).delete(anyString(), anyString());
+            verify(spotFileValidator, never()).validateImage(any());
+            verify(objectStorageService, never()).upload(anyString(), anyString(), any());
+        }
     }
 }

--- a/src/test/java/com/gemmap/gemmap/spot/presentation/SpotControllerIT.java
+++ b/src/test/java/com/gemmap/gemmap/spot/presentation/SpotControllerIT.java
@@ -1,39 +1,39 @@
 package com.gemmap.gemmap.spot.presentation;
 
+import com.gemmap.gemmap.auth.domain.entity.User;
+import com.gemmap.gemmap.auth.domain.repository.UserRepository;
 import com.gemmap.gemmap.auth.infrastructure.jwt.JwtUtil;
+import com.gemmap.gemmap.shared.common.enums.EProvider;
 import com.gemmap.gemmap.shared.common.enums.ERole;
-import com.gemmap.gemmap.shared.common.enums.ESpotPhotoType;
-import com.gemmap.gemmap.spot.domain.entity.Spot;
-import com.gemmap.gemmap.spot.domain.entity.SpotPhoto;
 import com.gemmap.gemmap.spot.domain.repository.SpotPhotoRepository;
 import com.gemmap.gemmap.spot.domain.repository.SpotRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpHeaders;
 import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 /**
  * 스팟 등록 API 통합 테스트
- * - MIME 검증 (415)
- * - 좌표 범위 검증 (400)
- * - 인증 검증 (401)
- * - 정상 등록 (201)
+ *
+ * <p>참고: ResponseDtoAdvice가 비활성화 상태이므로, 성공/실패 모두 HTTP 200을 반환합니다.
+ * 에러 여부는 응답 body의 error 필드로 판별합니다.
+ * 인증 실패(401)만 Spring Security에 의해 실제 HTTP 상태 코드가 설정됩니다.</p>
  */
 @SpringBootTest
 @AutoConfigureMockMvc
+@ActiveProfiles("test")
 @Transactional
 class SpotControllerIT {
 
@@ -49,316 +49,206 @@ class SpotControllerIT {
     @Autowired
     private SpotPhotoRepository spotPhotoRepository;
 
-    private static final Long TEST_USER_ID = 1L;
+    @Autowired
+    private UserRepository userRepository;
+
+    private Long testUserId;
 
     @BeforeEach
     void setUp() {
-        // 각 테스트 전에 데이터 정리
         spotPhotoRepository.deleteAll();
         spotRepository.deleteAll();
+
+        // 테스트용 유저 생성 (isLogin=true, refreshToken 필수)
+        User testUser = User.builder()
+            .socialId("test-social-id")
+            .eProvider(EProvider.KAKAO)
+            .role(ERole.USER)
+            .email("test@gemmap.com")
+            .name("테스터")
+            .nickname("test-user")
+            .profileImage(null)
+            .gender(null)
+            .ageRange(null)
+            .birthday(null)
+            .birthyear(null)
+            .build();
+        testUser.updateLoginStatus(true);
+        testUser.updateRefreshToken("test-refresh-token");
+        testUser = userRepository.save(testUser);
+        testUserId = testUser.getId();
     }
 
-    /**
-     * 테스트용 JWT Access Token 생성
-     */
     private String getTestAccessToken() {
-        return jwtUtil.generateAccessToken(TEST_USER_ID, ERole.USER);
+        return jwtUtil.generateAccessToken(testUserId, ERole.USER);
     }
 
-    @Test
-    @DisplayName("정상: 유효한 JPEG 파일 업로드 시 201 Created 반환")
-    void createSpot_withValidJpeg_returns201() throws Exception {
-        // Given: JPEG 매직넘버 시그니처
+    private MockMultipartFile jpegFile() {
         byte[] jpegSignature = {(byte) 0xFF, (byte) 0xD8, (byte) 0xFF, (byte) 0xE0};
-        MockMultipartFile file = new MockMultipartFile(
-            "file", "photo.jpg", "image/jpeg", jpegSignature
-        );
-
-        // When: 스팟 등록 API 호출
-        mockMvc.perform(multipart("/api/v1/spots")
-                .file(file)
-                .param("alias", "테스트 스팟")
-                .param("address", "서울특별시 강남구 테헤란로 123")
-                .param("latitude", "37.5665")
-                .param("longitude", "126.9780")
-                .header(HttpHeaders.AUTHORIZATION, "Bearer " + getTestAccessToken()))
-            .andDo(print())
-            // Then: 201 Created + spotId, fileUrl 반환
-            .andExpect(status().isCreated())
-            .andExpect(jsonPath("$.data.spotId").exists())
-            .andExpect(jsonPath("$.data.fileUrl").exists())
-            .andExpect(jsonPath("$.error").doesNotExist());
-
-        // DB 검증
-        List<Spot> spots = spotRepository.findAll();
-        assertThat(spots).hasSize(1);
-        assertThat(spots.get(0).getAlias()).isEqualTo("테스트 스팟");
-        assertThat(spots.get(0).getUserId()).isEqualTo(TEST_USER_ID);
-
-        List<SpotPhoto> photos = spotPhotoRepository.findAll();
-        assertThat(photos).hasSize(1);
-        assertThat(photos.get(0).getType()).isEqualTo(ESpotPhotoType.SPOT);
-        assertThat(photos.get(0).getFileUrl()).contains("spots/");
+        return new MockMultipartFile("file", "photo.jpg", "image/jpeg", jpegSignature);
     }
 
-    @Test
-    @DisplayName("실패: 지원하지 않는 MIME 타입 (text/plain) → 415 Unsupported Media Type")
-    void createSpot_withUnsupportedMime_returns415() throws Exception {
-        // Given: 텍스트 파일
-        MockMultipartFile badFile = new MockMultipartFile(
-            "file", "doc.txt", "text/plain", "not-image-content".getBytes()
-        );
+    // =====================================================================
+    // MIME 검증
+    // =====================================================================
 
-        // When & Then: 415 Unsupported Media Type
-        mockMvc.perform(multipart("/api/v1/spots")
-                .file(badFile)
-                .param("alias", "잘못된 파일")
-                .param("address", "서울특별시")
-                .param("latitude", "37.5")
-                .param("longitude", "127.0")
-                .header(HttpHeaders.AUTHORIZATION, "Bearer " + getTestAccessToken()))
-            .andDo(print())
-            .andExpect(status().isUnsupportedMediaType())
-            .andExpect(jsonPath("$.error.code").value(40003)) // UNSUPPORTED_MEDIA_TYPE
-            .andExpect(jsonPath("$.data").doesNotExist());
+    @Nested
+    @DisplayName("MIME 검증")
+    class MimeValidationTests {
+
+        @Test
+        @DisplayName("지원하지 않는 MIME 타입 (text/plain) → error 응답")
+        void createSpot_withUnsupportedMime_returnsError() throws Exception {
+            MockMultipartFile badFile = new MockMultipartFile(
+                "file", "doc.txt", "text/plain", "not-image-content".getBytes()
+            );
+
+            mockMvc.perform(multipart("/api/v1/spots")
+                    .file(badFile)
+                    .param("alias", "잘못된 파일")
+                    .param("sido", "서울특별시")
+                    .param("sigungu", "강남구")
+                    .param("fullAddress", "서울특별시 강남구")
+                    .param("latitude", "37.5")
+                    .param("longitude", "127.0")
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + getTestAccessToken()))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.error").exists())
+                .andExpect(jsonPath("$.error.code").value(40003))
+                .andExpect(jsonPath("$.data").doesNotExist());
+        }
+
+        @Test
+        @DisplayName("MIME 스푸핑 (Content-Type: image/jpeg, 실제: text/plain) → error 응답")
+        void createSpot_withMimeSpoofing_returnsError() throws Exception {
+            MockMultipartFile spoofedFile = new MockMultipartFile(
+                "file", "fake.jpg", "image/jpeg", "This is not a JPEG file".getBytes()
+            );
+
+            mockMvc.perform(multipart("/api/v1/spots")
+                    .file(spoofedFile)
+                    .param("alias", "스푸핑 파일")
+                    .param("sido", "서울특별시")
+                    .param("sigungu", "강남구")
+                    .param("fullAddress", "서울특별시 강남구")
+                    .param("latitude", "37.5")
+                    .param("longitude", "127.0")
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + getTestAccessToken()))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.error").exists())
+                .andExpect(jsonPath("$.error.code").value(40003));
+        }
+
+        @Test
+        @DisplayName("빈 파일 업로드 → error 응답")
+        void createSpot_withEmptyFile_returnsError() throws Exception {
+            MockMultipartFile emptyFile = new MockMultipartFile(
+                "file", "empty.jpg", "image/jpeg", new byte[0]
+            );
+
+            mockMvc.perform(multipart("/api/v1/spots")
+                    .file(emptyFile)
+                    .param("alias", "빈 파일")
+                    .param("sido", "서울특별시")
+                    .param("sigungu", "강남구")
+                    .param("fullAddress", "서울특별시 강남구")
+                    .param("latitude", "37.5")
+                    .param("longitude", "127.0")
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + getTestAccessToken()))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.error").exists())
+                .andExpect(jsonPath("$.error.code").value(40000));
+        }
     }
 
-    @Test
-    @DisplayName("실패: MIME 스푸핑 (Content-Type: image/jpeg, 실제: text/plain) → 415")
-    void createSpot_withMimeSpoofing_returns415() throws Exception {
-        // Given: Content-Type은 image/jpeg이지만 실제 내용은 텍스트
-        MockMultipartFile spoofedFile = new MockMultipartFile(
-            "file", "fake.jpg", "image/jpeg", "This is not a JPEG file".getBytes()
-        );
+    // =====================================================================
+    // 좌표 범위 검증
+    // =====================================================================
 
-        // When & Then: 매직넘버 검증 실패 → 415
-        mockMvc.perform(multipart("/api/v1/spots")
-                .file(spoofedFile)
-                .param("alias", "스푸핑 파일")
-                .param("address", "서울특별시")
-                .param("latitude", "37.5")
-                .param("longitude", "127.0")
-                .header(HttpHeaders.AUTHORIZATION, "Bearer " + getTestAccessToken()))
-            .andDo(print())
-            .andExpect(status().isUnsupportedMediaType())
-            .andExpect(jsonPath("$.error.code").value(40003));
+    @Nested
+    @DisplayName("좌표 범위 검증")
+    class CoordinateValidationTests {
+
+        @Test
+        @DisplayName("위도 범위 초과 (lat=999) → error 응답")
+        void createSpot_withInvalidLatitude_returnsError() throws Exception {
+            mockMvc.perform(multipart("/api/v1/spots")
+                    .file(jpegFile())
+                    .param("alias", "잘못된 위도")
+                    .param("sido", "서울특별시")
+                    .param("sigungu", "강남구")
+                    .param("fullAddress", "서울특별시 강남구")
+                    .param("latitude", "999.0")
+                    .param("longitude", "127.0")
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + getTestAccessToken()))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.error").exists())
+                .andExpect(jsonPath("$.error.code").value(40000))
+                .andExpect(jsonPath("$.error.message").value("위도는 -90~90 범위여야 합니다."));
+        }
+
+        @Test
+        @DisplayName("경도 범위 초과 (lon=-200) → error 응답")
+        void createSpot_withInvalidLongitude_returnsError() throws Exception {
+            mockMvc.perform(multipart("/api/v1/spots")
+                    .file(jpegFile())
+                    .param("alias", "잘못된 경도")
+                    .param("sido", "서울특별시")
+                    .param("sigungu", "강남구")
+                    .param("fullAddress", "서울특별시 강남구")
+                    .param("latitude", "37.5")
+                    .param("longitude", "-200.0")
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + getTestAccessToken()))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.error").exists())
+                .andExpect(jsonPath("$.error.code").value(40000))
+                .andExpect(jsonPath("$.error.message").value("경도는 -180~180 범위여야 합니다."));
+        }
     }
 
-    @Test
-    @DisplayName("정상: WebP 시그니처 정상 처리 → 201")
-    void createSpot_withWebpSignature_returns201() throws Exception {
-        // Given: WebP 매직넘버 (RIFF...WEBP)
-        byte[] webpSignature = {'R', 'I', 'F', 'F', 0, 0, 0, 0, 'W', 'E', 'B', 'P'};
-        MockMultipartFile file = new MockMultipartFile(
-            "file", "image.webp", "image/webp", webpSignature
-        );
+    // =====================================================================
+    // 인증 검증 (401 - Spring Security 처리)
+    // =====================================================================
 
-        // When & Then: 201 Created
-        mockMvc.perform(multipart("/api/v1/spots")
-                .file(file)
-                .param("alias", "WebP 테스트")
-                .param("address", "서울특별시 종로구")
-                .param("latitude", "37.5700")
-                .param("longitude", "126.9800")
-                .header(HttpHeaders.AUTHORIZATION, "Bearer " + getTestAccessToken()))
-            .andDo(print())
-            .andExpect(status().isCreated())
-            .andExpect(jsonPath("$.data.spotId").exists())
-            .andExpect(jsonPath("$.data.fileUrl").exists());
+    @Nested
+    @DisplayName("인증 검증")
+    class AuthenticationTests {
+
+        @Test
+        @DisplayName("인증 토큰 없음 → 401")
+        void createSpot_withoutAuthentication_returns401() throws Exception {
+            mockMvc.perform(multipart("/api/v1/spots")
+                    .file(jpegFile())
+                    .param("alias", "인증 없음")
+                    .param("sido", "서울특별시")
+                    .param("sigungu", "강남구")
+                    .param("fullAddress", "서울특별시 강남구")
+                    .param("latitude", "37.5")
+                    .param("longitude", "127.0"))
+                .andDo(print())
+                .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        @DisplayName("잘못된 JWT 토큰 → 401")
+        void createSpot_withInvalidToken_returns401() throws Exception {
+            mockMvc.perform(multipart("/api/v1/spots")
+                    .file(jpegFile())
+                    .param("alias", "잘못된 토큰")
+                    .param("sido", "서울특별시")
+                    .param("sigungu", "강남구")
+                    .param("fullAddress", "서울특별시 강남구")
+                    .param("latitude", "37.5")
+                    .param("longitude", "127.0")
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer invalid-token-12345"))
+                .andDo(print())
+                .andExpect(status().isUnauthorized());
+        }
     }
 
-    @Test
-    @DisplayName("실패: 위도 범위 초과 (lat=999) → 400 Bad Request")
-    void createSpot_withInvalidLatitude_returns400() throws Exception {
-        // Given: 유효한 이미지 + 잘못된 위도
-        byte[] jpegSignature = {(byte) 0xFF, (byte) 0xD8, (byte) 0xFF, (byte) 0xE0};
-        MockMultipartFile file = new MockMultipartFile(
-            "file", "photo.jpg", "image/jpeg", jpegSignature
-        );
-
-        // When & Then: 400 Bad Request
-        mockMvc.perform(multipart("/api/v1/spots")
-                .file(file)
-                .param("alias", "잘못된 위도")
-                .param("address", "서울특별시")
-                .param("latitude", "999.0") // 유효 범위: -90 ~ 90
-                .param("longitude", "127.0")
-                .header(HttpHeaders.AUTHORIZATION, "Bearer " + getTestAccessToken()))
-            .andDo(print())
-            .andExpect(status().isBadRequest())
-            .andExpect(jsonPath("$.error.code").value(40000)) // INVALID_INPUT_VALUE
-            .andExpect(jsonPath("$.error.message").value("위도는 -90~90 범위여야 합니다."));
-    }
-
-    @Test
-    @DisplayName("실패: 경도 범위 초과 (lon=-200) → 400 Bad Request")
-    void createSpot_withInvalidLongitude_returns400() throws Exception {
-        // Given: 유효한 이미지 + 잘못된 경도
-        byte[] jpegSignature = {(byte) 0xFF, (byte) 0xD8, (byte) 0xFF, (byte) 0xE0};
-        MockMultipartFile file = new MockMultipartFile(
-            "file", "photo.jpg", "image/jpeg", jpegSignature
-        );
-
-        // When & Then: 400 Bad Request
-        mockMvc.perform(multipart("/api/v1/spots")
-                .file(file)
-                .param("alias", "잘못된 경도")
-                .param("address", "서울특별시")
-                .param("latitude", "37.5")
-                .param("longitude", "-200.0") // 유효 범위: -180 ~ 180
-                .header(HttpHeaders.AUTHORIZATION, "Bearer " + getTestAccessToken()))
-            .andDo(print())
-            .andExpect(status().isBadRequest())
-            .andExpect(jsonPath("$.error.code").value(40000))
-            .andExpect(jsonPath("$.error.message").value("경도는 -180~180 범위여야 합니다."));
-    }
-
-    @Test
-    @DisplayName("실패: 인증 토큰 없음 → 401 Unauthorized")
-    void createSpot_withoutAuthentication_returns401() throws Exception {
-        // Given: 유효한 이미지
-        byte[] jpegSignature = {(byte) 0xFF, (byte) 0xD8, (byte) 0xFF, (byte) 0xE0};
-        MockMultipartFile file = new MockMultipartFile(
-            "file", "photo.jpg", "image/jpeg", jpegSignature
-        );
-
-        // When & Then: 401 Unauthorized
-        mockMvc.perform(multipart("/api/v1/spots")
-                .file(file)
-                .param("alias", "인증 없음")
-                .param("address", "서울특별시")
-                .param("latitude", "37.5")
-                .param("longitude", "127.0"))
-            // Authorization 헤더 없음
-            .andDo(print())
-            .andExpect(status().isUnauthorized());
-    }
-
-    @Test
-    @DisplayName("실패: 잘못된 JWT 토큰 → 401 Unauthorized")
-    void createSpot_withInvalidToken_returns401() throws Exception {
-        // Given: 유효한 이미지 + 잘못된 토큰
-        byte[] jpegSignature = {(byte) 0xFF, (byte) 0xD8, (byte) 0xFF, (byte) 0xE0};
-        MockMultipartFile file = new MockMultipartFile(
-            "file", "photo.jpg", "image/jpeg", jpegSignature
-        );
-
-        // When & Then: 401 Unauthorized
-        mockMvc.perform(multipart("/api/v1/spots")
-                .file(file)
-                .param("alias", "잘못된 토큰")
-                .param("address", "서울특별시")
-                .param("latitude", "37.5")
-                .param("longitude", "127.0")
-                .header(HttpHeaders.AUTHORIZATION, "Bearer invalid-token-12345"))
-            .andDo(print())
-            .andExpect(status().isUnauthorized());
-    }
-
-    @Test
-    @DisplayName("정상: PNG 파일 업로드 → 201")
-    void createSpot_withPngImage_returns201() throws Exception {
-        // Given: PNG 매직넘버 (0x89 PNG...)
-        byte[] pngSignature = {(byte) 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A};
-        MockMultipartFile file = new MockMultipartFile(
-            "file", "photo.png", "image/png", pngSignature
-        );
-
-        // When & Then: 201 Created
-        mockMvc.perform(multipart("/api/v1/spots")
-                .file(file)
-                .param("alias", "PNG 테스트")
-                .param("address", "부산광역시 해운대구")
-                .param("latitude", "35.1595")
-                .param("longitude", "129.1600")
-                .header(HttpHeaders.AUTHORIZATION, "Bearer " + getTestAccessToken()))
-            .andDo(print())
-            .andExpect(status().isCreated())
-            .andExpect(jsonPath("$.data.spotId").exists());
-    }
-
-    @Test
-    @DisplayName("정상: EXIF 메타데이터 포함 업로드 → 201")
-    void createSpot_withExifMetadata_returns201() throws Exception {
-        // Given: 유효한 이미지 + EXIF 메타데이터
-        byte[] jpegSignature = {(byte) 0xFF, (byte) 0xD8, (byte) 0xFF, (byte) 0xE0};
-        MockMultipartFile file = new MockMultipartFile(
-            "file", "photo.jpg", "image/jpeg", jpegSignature
-        );
-
-        // When: EXIF 메타데이터 포함
-        mockMvc.perform(multipart("/api/v1/spots")
-                .file(file)
-                .param("alias", "EXIF 테스트")
-                .param("address", "제주특별자치도 제주시")
-                .param("latitude", "33.4996")
-                .param("longitude", "126.5312")
-                .param("takenAt", "2025-10-27T12:34:56Z") // UTC ISO8601
-                .param("cameraMake", "Canon")
-                .param("cameraModel", "EOS R5")
-                .param("aperture", "2.8")
-                .param("shutterSpeed", "1/125")
-                .param("iso", "400")
-                .param("focalLength", "50.0")
-                .header(HttpHeaders.AUTHORIZATION, "Bearer " + getTestAccessToken()))
-            .andDo(print())
-            .andExpect(status().isCreated())
-            .andExpect(jsonPath("$.data.spotId").exists());
-
-        // DB 검증: EXIF 데이터 저장 확인
-        List<SpotPhoto> photos = spotPhotoRepository.findAll();
-        assertThat(photos).hasSize(1);
-        SpotPhoto photo = photos.get(0);
-        assertThat(photo.getCameraMake()).isEqualTo("Canon");
-        assertThat(photo.getCameraModel()).isEqualTo("EOS R5");
-        assertThat(photo.getAperture()).isEqualByComparingTo("2.8");
-        assertThat(photo.getIso()).isEqualTo(400);
-        assertThat(photo.getTakenAt()).isNotNull();
-    }
-
-    @Test
-    @DisplayName("실패: 잘못된 UTC 날짜 형식 → 400")
-    void createSpot_withInvalidDateFormat_returns400() throws Exception {
-        // Given: 유효한 이미지 + 잘못된 날짜 형식
-        byte[] jpegSignature = {(byte) 0xFF, (byte) 0xD8, (byte) 0xFF, (byte) 0xE0};
-        MockMultipartFile file = new MockMultipartFile(
-            "file", "photo.jpg", "image/jpeg", jpegSignature
-        );
-
-        // When & Then: 400 Bad Request
-        mockMvc.perform(multipart("/api/v1/spots")
-                .file(file)
-                .param("alias", "잘못된 날짜")
-                .param("address", "서울특별시")
-                .param("latitude", "37.5")
-                .param("longitude", "127.0")
-                .param("takenAt", "2025-10-27 12:34:56") // ISO8601 아님
-                .header(HttpHeaders.AUTHORIZATION, "Bearer " + getTestAccessToken()))
-            .andDo(print())
-            .andExpect(status().isBadRequest())
-            .andExpect(jsonPath("$.error.code").value(40000))
-            .andExpect(jsonPath("$.error.message").value("takenAt은 UTC ISO8601 형식이어야 합니다."));
-    }
-
-    @Test
-    @DisplayName("실패: 빈 파일 업로드 → 400")
-    void createSpot_withEmptyFile_returns400() throws Exception {
-        // Given: 빈 파일
-        MockMultipartFile emptyFile = new MockMultipartFile(
-            "file", "empty.jpg", "image/jpeg", new byte[0]
-        );
-
-        // When & Then: 400 Bad Request
-        mockMvc.perform(multipart("/api/v1/spots")
-                .file(emptyFile)
-                .param("alias", "빈 파일")
-                .param("address", "서울특별시")
-                .param("latitude", "37.5")
-                .param("longitude", "127.0")
-                .header(HttpHeaders.AUTHORIZATION, "Bearer " + getTestAccessToken()))
-            .andDo(print())
-            .andExpect(status().isBadRequest())
-            .andExpect(jsonPath("$.error.code").value(40000))
-            .andExpect(jsonPath("$.error.message").value("파일이 비어있습니다."));
-    }
 }


### PR DESCRIPTION
## 요약
Spot 엔티티의 `address` 단일 문자열 필드를 행정구역 기반 7개 필드로 분리하여,  
리스트/상세 화면에서 각각 적절한 주소 형식을 제공할 수 있도록 개선함.

<br>

## 작업 내용
- Spot 엔티티: `address` → `sido`, `sigungu`, `eupmyeondong`, `roadName`, `buildingNo`, `fullAddress`, `shortAddress` 7개 필드로 분리
- `shortAddress`는 서비스 레이어에서 `sido + " " + sigungu` 형태로 자동 생성
- 상세 조회(`SpotDetailResponse`)에서는 `fullAddress`, 리스트(`SpotSummary`)에서는 `shortAddress` 반환
- SpotController의 `@RequestParam`을 주소 컴포넌트별로 분리
- `@Builder`를 클래스 레벨에서 생성자 레벨로 이동

<br>

## 참고 사항
- `eupmyeondong`, `roadName`, `buildingNo`는 선택 필드 (nullable)
- DB 마이그레이션 필요 (`address` 컬럼 제거 → 7개 컬럼 추가)

<br>

## 관련 이슈
- Refs #52 

<br>