### PR TITLE
Refactor(spot): MarkerResponse에서 returnedCount 필드 제거

### DIFF
--- a/src/main/java/com/gemmap/gemmap/spot/application/dto/response/MarkerResponse.java
+++ b/src/main/java/com/gemmap/gemmap/spot/application/dto/response/MarkerResponse.java
@@ -7,10 +7,8 @@ import java.math.BigDecimal;
 import java.util.List;
 
 /** 마커 조회 응답 DTO **/
-@Builder
 public record MarkerResponse(
-        List<MarkerInfo> markers,
-        int returnedCount
+        List<MarkerInfo> markers
 ) {
 
     /** 개별 마커 정보 **/
@@ -29,9 +27,6 @@ public record MarkerResponse(
                         photo.getLongitude()))
                 .toList();
 
-        return MarkerResponse.builder()
-                .markers(markers)
-                .returnedCount(markers.size())
-                .build();
+        return new MarkerResponse(markers);
     }
 }


### PR DESCRIPTION
## 요약
`MarkerResponse`에서 `returnedCount` 필드를 제거함.

<br>

## 작업 내용
- `MarkerResponse`에서 `returnedCount` 필드 제거
- `@Builder` 어노테이션 제거 및 생성자 직접 호출로 간소화

<br>

## 참고 사항

<br>

## 관련 이슈
- Refs #56 

<br>