### PR TITLE
Feat(bookmark): 젬 찜하기 기능 구현 및 마이스팟 API 분리

### DIFF
--- a/src/main/java/com/gemmap/gemmap/bookmark/application/dto/response/BookmarkCreateResponse.java
+++ b/src/main/java/com/gemmap/gemmap/bookmark/application/dto/response/BookmarkCreateResponse.java
@@ -1,0 +1,21 @@
+package com.gemmap.gemmap.bookmark.application.dto.response;
+
+import com.gemmap.gemmap.bookmark.domain.entity.SpotBookmark;
+import com.gemmap.gemmap.shared.common.enums.EAttractionLevel;
+import lombok.Builder;
+
+@Builder
+public record BookmarkCreateResponse(
+        Long bookmarkId,
+        Long spotId,
+        EAttractionLevel attractionLevel
+) {
+
+    public static BookmarkCreateResponse of(SpotBookmark bookmark) {
+        return BookmarkCreateResponse.builder()
+                .bookmarkId(bookmark.getId())
+                .spotId(bookmark.getSpot().getId())
+                .attractionLevel(bookmark.getAttractionLevel())
+                .build();
+    }
+}

--- a/src/main/java/com/gemmap/gemmap/bookmark/application/dto/response/MyBookmarksResponse.java
+++ b/src/main/java/com/gemmap/gemmap/bookmark/application/dto/response/MyBookmarksResponse.java
@@ -1,0 +1,17 @@
+package com.gemmap.gemmap.bookmark.application.dto.response;
+
+import com.gemmap.gemmap.spot.application.dto.response.SpotSummary;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record MyBookmarksResponse (
+        List<SpotSummary> spots
+) {
+    public static MyBookmarksResponse of(List<SpotSummary> spots) {
+        return MyBookmarksResponse.builder()
+                .spots(spots)
+                .build();
+    }
+}

--- a/src/main/java/com/gemmap/gemmap/bookmark/application/service/BookmarkService.java
+++ b/src/main/java/com/gemmap/gemmap/bookmark/application/service/BookmarkService.java
@@ -1,0 +1,121 @@
+package com.gemmap.gemmap.bookmark.application.service;
+
+import com.gemmap.gemmap.auth.domain.entity.User;
+import com.gemmap.gemmap.auth.domain.repository.UserRepository;
+import com.gemmap.gemmap.bookmark.application.dto.response.BookmarkCreateResponse;
+import com.gemmap.gemmap.bookmark.application.dto.response.MyBookmarksResponse;
+import com.gemmap.gemmap.bookmark.domain.entity.SpotBookmark;
+import com.gemmap.gemmap.bookmark.domain.repository.SpotBookmarkRepository;
+import com.gemmap.gemmap.shared.common.enums.EAttractionLevel;
+import com.gemmap.gemmap.shared.common.enums.ESpotPhotoType;
+import com.gemmap.gemmap.shared.exception.CommonException;
+import com.gemmap.gemmap.shared.exception.ErrorCode;
+import com.gemmap.gemmap.spot.application.dto.response.SpotSummary;
+import com.gemmap.gemmap.spot.domain.entity.Spot;
+import com.gemmap.gemmap.spot.domain.entity.SpotPhoto;
+import com.gemmap.gemmap.spot.domain.repository.SpotPhotoRepository;
+import com.gemmap.gemmap.spot.domain.repository.SpotRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class BookmarkService {
+
+    private final UserRepository userRepository;
+    private final SpotRepository spotRepository;
+    private final SpotBookmarkRepository spotBookmarkRepository;
+    private final SpotPhotoRepository spotPhotoRepository;
+
+    /**
+     * 젬 찜하기 (북마크 생성)
+     */
+    @Transactional
+    public BookmarkCreateResponse createBookmark(
+            Long userId, Long spotId, EAttractionLevel attractionLevel
+    ) {
+        // 사용자 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CommonException(ErrorCode.USER_NOT_FOUND));
+
+        // 스팟 조회
+        Spot spot = spotRepository.findById(spotId)
+                .orElseThrow(() -> new CommonException(ErrorCode.SPOT_NOT_FOUND));
+
+        // 중복 찜 확인
+        if (spotBookmarkRepository.existsByUserAndSpot(user, spot)) {
+            throw new CommonException(ErrorCode.BOOKMARK_ALREADY_EXISTS);
+        }
+
+        // SpotBookmark 엔티티 생성 + 저장
+        SpotBookmark bookmark = SpotBookmark.builder()
+                .user(user)
+                .spot(spot)
+                .attractionLevel(attractionLevel)
+                .build();
+        spotBookmarkRepository.save(bookmark);
+
+        return BookmarkCreateResponse.of(bookmark);
+    }
+
+    /**
+     * 찜하기 취소
+     */
+    @Transactional
+    public void deleteBookmark(Long userId, Long spotId) {
+        // 북마크 조회
+        SpotBookmark bookmark = spotBookmarkRepository.findByUserIdAndSpotId(userId, spotId)
+                .orElseThrow(() -> new CommonException(ErrorCode.BOOKMARK_NOT_FOUND));
+
+        spotBookmarkRepository.delete(bookmark);
+    }
+
+    /**
+     * 끌림지수 조회
+     * → SpotService.getSpotDetail() 에서 호출
+     *
+     * @return 끌림지수 (북마크 없으면 null)
+     */
+    @Transactional(readOnly = true)
+    public EAttractionLevel getAttractionLevel(Long userId, Long spotId) {
+        return spotBookmarkRepository.findByUserIdAndSpotId(userId, spotId)
+                .map(SpotBookmark::getAttractionLevel)
+                .orElse(null);
+    }
+
+    /**
+     * 찜한 젬 목록 조회 (마이스팟)
+     * → SpotController GET /me/bookmarked 에서 호출
+     */
+    @Transactional(readOnly = true)
+    public MyBookmarksResponse getMyBookmarkedSpots(Long userId) {
+        // 찜한 북마크 목록 조회 (최신순)
+        List<SpotBookmark> bookmarks = spotBookmarkRepository.findByUserIdOrderByCreatedAtDesc(userId);
+
+        // 각 북마크 -> 스팟 사진 URL 조회 -> SpotSummary 변환
+        List<SpotSummary> spotSummaries = bookmarks.stream()
+                .map(bookmark -> {
+                    Spot spot = bookmark.getSpot();
+                    String fileUrl = spotPhotoRepository
+                            .findFirstBySpotAndTypeOrderByCreatedAtDesc(spot, ESpotPhotoType.SPOT)
+                            .map(SpotPhoto::getFileUrl)
+                            .orElse(null);
+                    return SpotSummary.of(spot, fileUrl);
+                })
+                .toList();
+
+        return MyBookmarksResponse.of(spotSummaries);
+    }
+
+    /**
+     * 찜한 젬 개수 조회
+     * → SpotService.getMySpots() 에서 호출
+     */
+    @Transactional(readOnly = true)
+    public Integer getBookmarkedCount(Long userId) {
+        return spotBookmarkRepository.countByUserId(userId);
+    }
+}

--- a/src/main/java/com/gemmap/gemmap/bookmark/domain/entity/SpotBookmark.java
+++ b/src/main/java/com/gemmap/gemmap/bookmark/domain/entity/SpotBookmark.java
@@ -1,0 +1,52 @@
+package com.gemmap.gemmap.bookmark.domain.entity;
+
+import com.gemmap.gemmap.auth.domain.entity.User;
+import com.gemmap.gemmap.shared.common.enums.EAttractionLevel;
+import com.gemmap.gemmap.spot.domain.entity.Spot;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "spot_bookmarks",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_spot_bookmarks_user_spot",
+                columnNames = {"user_id", "spot_id"}
+        ))
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class SpotBookmark {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "spot_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private Spot spot;
+
+    @Column(name = "attraction_level", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private EAttractionLevel attractionLevel;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Builder
+    public SpotBookmark(User user, Spot spot, EAttractionLevel attractionLevel) {
+        this.user = user;
+        this.spot = spot;
+        this.attractionLevel = attractionLevel;
+    }
+}

--- a/src/main/java/com/gemmap/gemmap/bookmark/domain/repository/SpotBookmarkRepository.java
+++ b/src/main/java/com/gemmap/gemmap/bookmark/domain/repository/SpotBookmarkRepository.java
@@ -1,0 +1,24 @@
+package com.gemmap.gemmap.bookmark.domain.repository;
+
+import com.gemmap.gemmap.auth.domain.entity.User;
+import com.gemmap.gemmap.bookmark.domain.entity.SpotBookmark;
+import com.gemmap.gemmap.spot.domain.entity.Spot;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface SpotBookmarkRepository extends JpaRepository<SpotBookmark, Long> {
+
+    /** 중복 찜 방지 **/
+    boolean existsByUserAndSpot(User user, Spot spot);
+
+    /** 찜 취소 / 끌림지수 조회 **/
+    Optional<SpotBookmark> findByUserIdAndSpotId(Long userId, Long spotId);
+
+    /** 찜한 젬 목록 (최신순) **/
+    List<SpotBookmark> findByUserIdOrderByCreatedAtDesc(Long userId);
+
+    /** 찜한 젬 개수 **/
+    Integer countByUserId(Long userId);
+}

--- a/src/main/java/com/gemmap/gemmap/bookmark/presentation/BookmarkController.java
+++ b/src/main/java/com/gemmap/gemmap/bookmark/presentation/BookmarkController.java
@@ -1,0 +1,44 @@
+package com.gemmap.gemmap.bookmark.presentation;
+
+import com.gemmap.gemmap.bookmark.application.dto.response.BookmarkCreateResponse;
+import com.gemmap.gemmap.bookmark.application.service.BookmarkService;
+import com.gemmap.gemmap.shared.common.annotation.UserId;
+import com.gemmap.gemmap.shared.common.enums.EAttractionLevel;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/bookmarks")
+@RequiredArgsConstructor
+public class BookmarkController {
+
+    private final BookmarkService bookmarkService;
+
+    /**
+     * 젬 찜하기
+     */
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<BookmarkCreateResponse> createBookmark(
+            @UserId Long userId,
+            @RequestParam Long spotId,
+            @RequestParam EAttractionLevel attractionLevel
+    ){
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(bookmarkService.createBookmark(userId, spotId, attractionLevel));
+    }
+
+    /**
+     * 찜하기 취소
+     */
+    @DeleteMapping("/{spotId}")
+    public ResponseEntity<Void> deleteBookmark(
+            @UserId Long userId,
+            @PathVariable Long spotId
+    ) {
+        bookmarkService.deleteBookmark(userId, spotId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/gemmap/gemmap/shared/common/constants/Constant.java
+++ b/src/main/java/com/gemmap/gemmap/shared/common/constants/Constant.java
@@ -41,7 +41,8 @@ public class Constant {
     public static final String[] USER_URLS = {
             "/api/v1/users/**",
             "/api/v1/spots/**",
-            "/api/v1/markers/**"
+            "/api/v1/markers/**",
+            "/api/v1/bookmarks/**"
     };
 
     // 관리자만 접근 가능한 경로

--- a/src/main/java/com/gemmap/gemmap/shared/common/enums/EAttractionLevel.java
+++ b/src/main/java/com/gemmap/gemmap/shared/common/enums/EAttractionLevel.java
@@ -1,0 +1,7 @@
+package com.gemmap.gemmap.shared.common.enums;
+
+public enum EAttractionLevel {
+    LIKE_IT,    // 마음에 들어요
+    LOOKS_OKAY, // 괜찮아 보여요
+    NOT_SURE    // 모르겠어요
+}

--- a/src/main/java/com/gemmap/gemmap/shared/exception/ErrorCode.java
+++ b/src/main/java/com/gemmap/gemmap/shared/exception/ErrorCode.java
@@ -41,6 +41,7 @@ public enum ErrorCode {
     USER_NOT_FOUND(40401, HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
     SPOT_NOT_FOUND(40402, HttpStatus.NOT_FOUND, "스팟을 찾을 수 없습니다."),
     SPOT_PHOTO_NOT_FOUND(40403, HttpStatus.NOT_FOUND, "스팟 사진을 찾을 수 없습니다."),
+    BOOKMARK_NOT_FOUND(40404, HttpStatus.NOT_FOUND, "북마크를 찾을 수 없습니다."),
 
     // 415 Unsupported Media Type
     UNSUPPORTED_MEDIA_TYPE(41500, HttpStatus.UNSUPPORTED_MEDIA_TYPE, "지원하지 않는 미디어 타입입니다."),
@@ -49,6 +50,7 @@ public enum ErrorCode {
     CONFLICT(40900, HttpStatus.CONFLICT, "요청이 현재 리소스 상태와 충돌합니다."),
     ALREADY_EXISTS(40901, HttpStatus.CONFLICT, "이미 존재하는 데이터입니다."),
     ALREADY_REGISTERED_USER(40902, HttpStatus.CONFLICT, "이미 회원가입이 완료된 사용자입니다."),
+    BOOKMARK_ALREADY_EXISTS(40903, HttpStatus.CONFLICT, "이미 찜한 젬입니다."),
 
     // 500 Internal Server Error
     INTERNAL_SERVER_ERROR(50000, HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다."),

--- a/src/main/java/com/gemmap/gemmap/spot/application/dto/response/MyCreatedSpotsResponse.java
+++ b/src/main/java/com/gemmap/gemmap/spot/application/dto/response/MyCreatedSpotsResponse.java
@@ -1,0 +1,16 @@
+package com.gemmap.gemmap.spot.application.dto.response;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record MyCreatedSpotsResponse(
+        List<SpotSummary> spots
+) {
+    public static MyCreatedSpotsResponse of(List<SpotSummary> spots) {
+        return MyCreatedSpotsResponse.builder()
+                .spots(spots)
+                .build();
+    }
+}

--- a/src/main/java/com/gemmap/gemmap/spot/application/dto/response/MySpotsResponse.java
+++ b/src/main/java/com/gemmap/gemmap/spot/application/dto/response/MySpotsResponse.java
@@ -12,15 +12,15 @@ import java.util.List;
 public record MySpotsResponse(
         String profileImage,    // 사용자 프로필 이미지
         String nickname,        // 사용자 닉네임
-        Integer mySpotCount,    // 제보한 젬 개수 (전체)
-        List<SpotSummary> spots // 제보한 젬 목록
+        Integer createdCount, // 제보한 젬 개수
+        Integer bookmarkedCount   // 찜(북마크)한 젬 개수
 ) {
-    public static MySpotsResponse of(User user, Integer totalCount, List<SpotSummary> spots) {
+    public static MySpotsResponse of(User user, Integer createdCount, Integer bookmarkedCount) {
         return MySpotsResponse.builder()
                 .profileImage(user.getProfileImage())
                 .nickname(user.getNickname())
-                .mySpotCount(totalCount)
-                .spots(spots)
+                .createdCount(createdCount)
+                .bookmarkedCount(bookmarkedCount)
                 .build();
     }
 }

--- a/src/main/java/com/gemmap/gemmap/spot/application/dto/response/SpotDetailResponse.java
+++ b/src/main/java/com/gemmap/gemmap/spot/application/dto/response/SpotDetailResponse.java
@@ -1,6 +1,7 @@
 package com.gemmap.gemmap.spot.application.dto.response;
 
 import com.gemmap.gemmap.auth.domain.entity.User;
+import com.gemmap.gemmap.shared.common.enums.EAttractionLevel;
 import com.gemmap.gemmap.spot.domain.entity.Spot;
 import com.gemmap.gemmap.spot.domain.entity.SpotPhoto;
 import lombok.Builder;
@@ -12,25 +13,26 @@ import java.time.temporal.ChronoUnit;
 
 @Builder
 public record SpotDetailResponse(
-        Long spotId,            // 스팟 ID
-        String profileImage,    // 사용자 프로필 이미지
-        String nickname,        // 사용자 닉네임
-        String alias,           // 스팟 별칭
-        String fileUrl,         // 사진 URL
-        String address,         // 전체 주소
-        String takenAt,         // 촬영시각(KST, ISO-8601)
-        BigDecimal latitude,    // 위도
-        BigDecimal longitude,   // 경도
-        String cameraMake,      // 카메라 브랜드
-        String cameraModel,     // 카메라 모델
-        BigDecimal aperture,    // 조리개
-        String shutterSpeed,    // 셔터속도
-        Integer iso,            // ISO
-        BigDecimal focalLength, // 초점거리
-        String createdAt        // 생성시각(스팟, KST, ISO-8601)
+        Long spotId,                      // 스팟 ID
+        String profileImage,              // 사용자 프로필 이미지
+        String nickname,                  // 사용자 닉네임
+        String alias,                     // 스팟 별칭
+        String fileUrl,                   // 사진 URL
+        String address,                   // 전체 주소
+        EAttractionLevel attractionLevel, // 나의 평가 (끌림지수), null이면 찜하기 하지 않은 경우
+        String takenAt,                   // 촬영시각(KST, ISO-8601)
+        BigDecimal latitude,              // 위도
+        BigDecimal longitude,             // 경도
+        String cameraMake,                // 카메라 브랜드
+        String cameraModel,               // 카메라 모델
+        BigDecimal aperture,              // 조리개
+        String shutterSpeed,              // 셔터속도
+        Integer iso,                      // ISO
+        BigDecimal focalLength,           // 초점거리
+        String createdAt                  // 생성시각(스팟, KST, ISO-8601)
 ) {
 
-    public static SpotDetailResponse from (Spot spot, User spotOwner, SpotPhoto photo) {
+    public static SpotDetailResponse from (Spot spot, User spotOwner, SpotPhoto photo, EAttractionLevel attractionLevel) {
         return SpotDetailResponse.builder()
                 .spotId(spot.getId())
                 .profileImage(spotOwner.getProfileImage())
@@ -38,6 +40,7 @@ public record SpotDetailResponse(
                 .alias(spot.getAlias())
                 .fileUrl(photo.getFileUrl())
                 .address(spot.getFullAddress())
+                .attractionLevel(attractionLevel)
                 .takenAt(toKstIso(photo.getTakenAt())) // LocalDateTime/Instant/OffsetDateTime 대응
                 .latitude(photo.getLatitude())
                 .longitude(photo.getLongitude())

--- a/src/main/java/com/gemmap/gemmap/spot/application/service/SpotService.java
+++ b/src/main/java/com/gemmap/gemmap/spot/application/service/SpotService.java
@@ -2,6 +2,7 @@ package com.gemmap.gemmap.spot.application.service;
 
 import com.gemmap.gemmap.auth.domain.entity.User;
 import com.gemmap.gemmap.auth.domain.repository.UserRepository;
+import com.gemmap.gemmap.bookmark.application.service.BookmarkService;
 import com.gemmap.gemmap.image.infrastructure.objectstorage.ObjectStorageService;
 import com.gemmap.gemmap.image.infrastructure.objectstorage.S3UrlGenerator;
 import com.gemmap.gemmap.shared.common.enums.ESpotPhotoType;
@@ -42,6 +43,7 @@ public class SpotService {
 
     private static final ZoneId KST = ZoneId.of("Asia/Seoul");
 
+    private final BookmarkService bookmarkService;
     private final SpotRepository spotRepository;
     private final UserRepository userRepository;
     private final SpotPhotoRepository spotPhotoRepository;
@@ -262,8 +264,7 @@ public class SpotService {
             .map(SpotPhoto::getFileUrl)
             .toList();
 
-        // 5) DB 삭제 (트랜잭션 내): spot_photos → spots 순서 (cascade 없으므로 명시 삭제)
-        spotPhotoRepository.deleteAll(photos);
+        // 5) DB 삭제
         spotRepository.delete(spot);
 
         // 6) Object Storage 삭제 (트랜잭션 외부, 베스트 에포트)

--- a/src/main/java/com/gemmap/gemmap/spot/application/service/SpotService.java
+++ b/src/main/java/com/gemmap/gemmap/spot/application/service/SpotService.java
@@ -313,8 +313,11 @@ public class SpotService {
                 findFirstBySpotAndTypeOrderByCreatedAtDesc(spot, ESpotPhotoType.SPOT)
                 .orElseThrow(() -> new CommonException(ErrorCode.SPOT_PHOTO_NOT_FOUND, "스팟 사진이 존재하지 않습니다."));
 
-        // 5) 응답 DTO 변환
-        return SpotDetailResponse.from(spot, spotOwner, representativePhoto);
+        // 5) 끌림지수(나의 평가) 조회 - 찜하기 하지 않은 경우 null
+        EAttractionLevel attractionLevel = bookmarkService.getAttractionLevel(userId, spotId);
+
+        // 6) 응답 DTO 변환
+        return SpotDetailResponse.from(spot, spotOwner, representativePhoto, attractionLevel);
     }
 
     /**

--- a/src/main/java/com/gemmap/gemmap/spot/application/service/SpotService.java
+++ b/src/main/java/com/gemmap/gemmap/spot/application/service/SpotService.java
@@ -5,6 +5,7 @@ import com.gemmap.gemmap.auth.domain.repository.UserRepository;
 import com.gemmap.gemmap.bookmark.application.service.BookmarkService;
 import com.gemmap.gemmap.image.infrastructure.objectstorage.ObjectStorageService;
 import com.gemmap.gemmap.image.infrastructure.objectstorage.S3UrlGenerator;
+import com.gemmap.gemmap.shared.common.enums.EAttractionLevel;
 import com.gemmap.gemmap.shared.common.enums.ESpotPhotoType;
 import com.gemmap.gemmap.shared.config.s3.S3Properties;
 import com.gemmap.gemmap.shared.exception.CommonException;
@@ -34,7 +35,6 @@ import java.time.format.DateTimeParseException;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -321,42 +321,48 @@ public class SpotService {
     }
 
     /**
-     * 내가 제보한 스팟 목록 조회
-     *
-     * @param userId 요청 사용자 ID
-     * @return MySpotsResponse
+     * 마이 스팟 조회 (사용자 정보 + 카운트: 제보/찜)
      */
     @Transactional(readOnly = true)
     public MySpotsResponse getMySpots(Long userId) {
-        // 1) 사용자 조회
+        // 사용자 조회
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CommonException(ErrorCode.USER_NOT_FOUND));
 
-        // 2) 사용자가 등록한 스팟 전체 개수 조회
-        Integer totalCount = spotRepository.countByUser(user);
+        // 제보한 젬 개수
+        Integer createdCount = spotRepository.countByUser(user);
+        // 찜한 젬 개수
+        Integer bookmarkedCount = bookmarkService.getBookmarkedCount(userId);
 
-        // 3) 사용자가 등록한 스팟 목록 조회 (최신순)
+        return MySpotsResponse.of(user, createdCount, bookmarkedCount);
+    }
+
+    /**
+     * 제보한 젬 목록 조회
+     */
+    @Transactional(readOnly = true)
+    public MyCreatedSpotsResponse getMyCreatedSpots(Long userId) {
+        // 사용자 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CommonException(ErrorCode.USER_NOT_FOUND));
+
+        // 사용자가 등록한 스팟 목록 조회 (최신순)
         List<Spot> spots = spotRepository.findByUserOrderByCreatedAtDesc(user);
 
-        // 4) 각 스팟에 대한 사진(type=SPOT, user=요청 사용자) 조회 후 DTO 변환
-        //    - 사진 없으면 해당 스팟은 노출하되 fileUrl = null
-        //    - 스팟 목록 자체가 없으면 자연스럽게 빈 리스트 반환
-        // TODO: N+1 문제 보완 가능 - @EntityGraph 또는 Batch Fetch 전략 고려
-        // 현재 요구사항에서는 per-spot 1회 조회로 충분하나, 스팟이 많아질 경우 최적화 필요
+        // 각 스팟의 대표 사진 URL 조회 -> SpotSummary 변환
         List<SpotSummary> spotSummaries = spots.stream()
                 .map(spot -> {
-                    // 각 spot마다 DB 쿼리 1회 발생 → N+1 문제
                     String fileUrl = spotPhotoRepository
                             .findFirstBySpotAndUserAndTypeOrderByCreatedAtDesc(spot, user, ESpotPhotoType.SPOT)
                             .map(SpotPhoto::getFileUrl)
                             .orElse(null);
                     return SpotSummary.of(spot, fileUrl);
                 })
-                .collect(Collectors.toList());
+                .toList();
 
-        // 5) 응답 DTO 변환
-        return MySpotsResponse.of(user, totalCount, spotSummaries);
+        return MyCreatedSpotsResponse.of(spotSummaries);
     }
+
 
     /**
      * 지도 전체 마커 조회

--- a/src/main/java/com/gemmap/gemmap/spot/domain/entity/SpotPhoto.java
+++ b/src/main/java/com/gemmap/gemmap/spot/domain/entity/SpotPhoto.java
@@ -5,6 +5,8 @@ import com.gemmap.gemmap.shared.common.enums.ESpotPhotoType;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 import org.locationtech.jts.geom.Point;
 
 import java.math.BigDecimal;
@@ -30,6 +32,7 @@ public class SpotPhoto {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "spot_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Spot spot; // 스팟 id
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/gemmap/gemmap/spot/presentation/SpotController.java
+++ b/src/main/java/com/gemmap/gemmap/spot/presentation/SpotController.java
@@ -1,5 +1,7 @@
 package com.gemmap.gemmap.spot.presentation;
 
+import com.gemmap.gemmap.bookmark.application.dto.response.MyBookmarksResponse;
+import com.gemmap.gemmap.bookmark.application.service.BookmarkService;
 import com.gemmap.gemmap.shared.common.annotation.UserId;
 import com.gemmap.gemmap.spot.application.dto.request.SpotCreateRequest;
 import com.gemmap.gemmap.spot.application.dto.response.MySpotsResponse;
@@ -22,6 +24,7 @@ import java.math.BigDecimal;
 public class SpotController {
 
     private final SpotService spotService;
+    private final BookmarkService bookmarkService;
 
     /**
      * 스팟 생성
@@ -113,6 +116,16 @@ public class SpotController {
             @UserId Long userId
     ) {
         return ResponseEntity.ok(spotService.getMySpots(userId));
+    }
+
+    /**
+     * 찜한 젬 목록 조회 (마이스팟)
+     */
+    @GetMapping("/me/bookmarked")
+    public ResponseEntity<MyBookmarksResponse> getMyBookmarkedSpots(
+            @UserId Long userId
+    ) {
+        return ResponseEntity.ok(bookmarkService.getMyBookmarkedSpots(userId));
     }
 
     /**

--- a/src/main/java/com/gemmap/gemmap/spot/presentation/SpotController.java
+++ b/src/main/java/com/gemmap/gemmap/spot/presentation/SpotController.java
@@ -4,11 +4,9 @@ import com.gemmap.gemmap.bookmark.application.dto.response.MyBookmarksResponse;
 import com.gemmap.gemmap.bookmark.application.service.BookmarkService;
 import com.gemmap.gemmap.shared.common.annotation.UserId;
 import com.gemmap.gemmap.spot.application.dto.request.SpotCreateRequest;
-import com.gemmap.gemmap.spot.application.dto.response.MySpotsResponse;
-import com.gemmap.gemmap.spot.application.dto.response.SpotCreateResponse;
-import com.gemmap.gemmap.spot.application.dto.response.SpotDetailResponse;
-import com.gemmap.gemmap.spot.application.dto.response.SpotsResponse;
+import com.gemmap.gemmap.spot.application.dto.response.*;
 import com.gemmap.gemmap.spot.application.service.SpotService;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -28,21 +26,6 @@ public class SpotController {
 
     /**
      * 스팟 생성
-     *
-     * @param userId 인증된 사용자 ID
-     * @param file 업로드할 이미지 파일
-     * @param alias 스팟 별칭
-     * @param address 도로명 주소
-     * @param takenAt 촬영 시각 (UTC ISO8601 형식, optional)
-     * @param latitude 위도
-     * @param longitude 경도
-     * @param cameraMake 카메라 브랜드 (optional)
-     * @param cameraModel 카메라 모델 (optional)
-     * @param aperture 조리개 값 (optional)
-     * @param shutterSpeed 셔터 속도 (optional)
-     * @param iso ISO 값 (optional)
-     * @param focalLength 초점 거리 (optional)
-     * @return 생성된 스팟 정보
      */
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<SpotCreateResponse> create(
@@ -76,10 +59,6 @@ public class SpotController {
 
     /**
      * 스팟 삭제
-     *
-     * @param userId 인증된 사용자 ID
-     * @param spotId 삭제할 스팟 ID
-     * @return 삭제 성공 응답
      */
     @DeleteMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<Void> delete(
@@ -92,10 +71,6 @@ public class SpotController {
 
     /**
      * 스팟 상세 조회
-     *
-     * @param userId 인증된 사용자 ID
-     * @param spotId 조회할 스팟 ID
-     * @return 스팟 상세 정보
      */
     @GetMapping("/{spotId}")
     public ResponseEntity<SpotDetailResponse> getSpotDetail(
@@ -106,16 +81,23 @@ public class SpotController {
     }
 
     /**
-     * 내가 제보한 스팟 목록 조회
-     *
-     * @param userId 인증된 사용자 ID
-     * @return 내가 제보한 스팟 목록 (프로필 정보 + 스팟 목록)
+     * 마이 스팟 조회 (사용자 정보 + 카운트: 제보/찜)
      */
     @GetMapping("/me")
     public ResponseEntity<MySpotsResponse> getMySpots(
             @UserId Long userId
     ) {
         return ResponseEntity.ok(spotService.getMySpots(userId));
+    }
+
+    /**
+     * 제보한 젬 목록 조회 (마이스팟)
+     */
+    @GetMapping("/me/created")
+    public ResponseEntity<MyCreatedSpotsResponse> getMyCreatedSpots(
+            @UserId Long userId
+    ) {
+        return ResponseEntity.ok(spotService.getMyCreatedSpots(userId));
     }
 
     /**
@@ -130,8 +112,6 @@ public class SpotController {
 
     /**
      * 지도 전체 마커 조회
-     *
-     * @param userId 인증된 사용자 ID
      */
     @GetMapping("/markers")
     public ResponseEntity<SpotsResponse> getSpots(


### PR DESCRIPTION
## 요약
스팟 상세 화면에서 젬을 찜하고 끌림지수를 선택하는 기능을 구현하고, 마이스팟 API를 카운트/목록으로 분리함.

<br>

## 작업 내용
- 신규 bookmark 모듈
	- 젬 찜하기 API (`POST /api/v1/bookmarks`) — 끌림지수(LIKE_IT, LOOKS_OKAY, NOT_SURE) 선택
	- 찜하기 취소 API (`DELETE /api/v1/bookmarks/{spotId}`)
	- `SpotBookmark` 엔티티 + `(user_id, spot_id)` UNIQUE 제약
- 기존 API 변경
	- 스팟 상세 조회 응답에 `attractionLevel` 필드 추가 (null이면 미찜)
	- 마이스팟 API(`GET /me`) — 카운트만 반환하도록 변경 (`createdCount`, `bookmarkedCount`)
	- 제보한 젬 목록 API(`GET /me/created`) 신규 분리
	- 찜한 젬 목록 API(`GET /me/bookmarked`) 신규 추가
- 인프라 변경
	- `SpotPhoto.spot`에 `@OnDelete(CASCADE)` 추가 — Spot 삭제 시 DB 레벨 cascade
	- `ErrorCode`에 BOOKMARK_NOT_FOUND(40404), BOOKMARK_ALREADY_EXISTS(40903) 추가

<br>

## 참고 사항
- 별도 `bookmark` 모듈로 분리 (spot 모듈 비대화 방지)
- cross-module 의존: SpotController/SpotService → BookmarkService (역방향 없음)
- 설계 문서: `docs/gem-bookmark/01~04` (로컬)

<br>

## 관련 이슈
- Refs #59  

<br>