### PR TITLE
Feat(spot): 스팟 상세 조회에 찜 개수(bookmarkedCount) 반환 추가

### DIFF
--- a/src/main/java/com/gemmap/gemmap/bookmark/application/service/BookmarkService.java
+++ b/src/main/java/com/gemmap/gemmap/bookmark/application/service/BookmarkService.java
@@ -118,4 +118,13 @@ public class BookmarkService {
     public Integer getBookmarkedCount(Long userId) {
         return spotBookmarkRepository.countByUserId(userId);
     }
+
+    /**
+     * 스팟의 찜 받은 개수 조회
+     * → SpotService.getSpotDetail() 에서 호출
+     */
+    @Transactional(readOnly = true)
+    public Integer getBookmarkedCountBySpot(Long spotId) {
+        return spotBookmarkRepository.countBySpotId(spotId);
+    }
 }

--- a/src/main/java/com/gemmap/gemmap/bookmark/domain/repository/SpotBookmarkRepository.java
+++ b/src/main/java/com/gemmap/gemmap/bookmark/domain/repository/SpotBookmarkRepository.java
@@ -21,4 +21,7 @@ public interface SpotBookmarkRepository extends JpaRepository<SpotBookmark, Long
 
     /** 찜한 젬 개수 **/
     Integer countByUserId(Long userId);
+
+    /** 스팟의 찜 받은 개수 **/
+    Integer countBySpotId(Long spotId);
 }

--- a/src/main/java/com/gemmap/gemmap/spot/application/dto/response/SpotDetailResponse.java
+++ b/src/main/java/com/gemmap/gemmap/spot/application/dto/response/SpotDetailResponse.java
@@ -19,6 +19,7 @@ public record SpotDetailResponse(
         String alias,                     // 스팟 별칭
         String fileUrl,                   // 사진 URL
         String address,                   // 전체 주소
+        Integer bookmarkedCount,          // 찜한 총 개수
         EAttractionLevel attractionLevel, // 나의 평가 (끌림지수), null이면 찜하기 하지 않은 경우
         String takenAt,                   // 촬영시각(KST, ISO-8601)
         BigDecimal latitude,              // 위도
@@ -32,7 +33,9 @@ public record SpotDetailResponse(
         String createdAt                  // 생성시각(스팟, KST, ISO-8601)
 ) {
 
-    public static SpotDetailResponse from (Spot spot, User spotOwner, SpotPhoto photo, EAttractionLevel attractionLevel) {
+    public static SpotDetailResponse from (Spot spot, User spotOwner, SpotPhoto photo,
+                                           Integer bookmarkedCount,
+                                           EAttractionLevel attractionLevel) {
         return SpotDetailResponse.builder()
                 .spotId(spot.getId())
                 .profileImage(spotOwner.getProfileImage())
@@ -40,6 +43,7 @@ public record SpotDetailResponse(
                 .alias(spot.getAlias())
                 .fileUrl(photo.getFileUrl())
                 .address(spot.getFullAddress())
+                .bookmarkedCount(bookmarkedCount)
                 .attractionLevel(attractionLevel)
                 .takenAt(toKstIso(photo.getTakenAt())) // LocalDateTime/Instant/OffsetDateTime 대응
                 .latitude(photo.getLatitude())

--- a/src/main/java/com/gemmap/gemmap/spot/application/service/SpotService.java
+++ b/src/main/java/com/gemmap/gemmap/spot/application/service/SpotService.java
@@ -316,8 +316,11 @@ public class SpotService {
         // 5) 끌림지수(나의 평가) 조회 - 찜하기 하지 않은 경우 null
         EAttractionLevel attractionLevel = bookmarkService.getAttractionLevel(userId, spotId);
 
-        // 6) 응답 DTO 변환
-        return SpotDetailResponse.from(spot, spotOwner, representativePhoto, attractionLevel);
+        // 6) 이 스팟(젬)을 찜한 총 개수 조회
+        Integer bookmarkedCount = bookmarkService.getBookmarkedCountBySpot(spotId);
+
+        // 7) 응답 DTO 변환
+        return SpotDetailResponse.from(spot, spotOwner, representativePhoto, bookmarkedCount, attractionLevel);
     }
 
     /**


### PR DESCRIPTION
## 요약
스팟 상세 조회 API(`GET /api/v1/spots/{spotId}`)에 해당 스팟을 찜한 총 개수(`bookmarkedCount`)를 반환하도록 추가함.

<br>

## 작업 내용
- `SpotBookmarkRepository`에 `countBySpotId()` 쿼리 메서드 추가
- `BookmarkService`에 `getBookmarkedCountBySpot()` 메서드 추가
- `SpotDetailResponse`에 `bookmarkedCount` 필드 추가
- `SpotService.getSpotDetail()`에서 찜 개수 조회 연동

<br>

## 참고 사항
- 프론트에서 찜하기/취소 시 `bookmarkedCount`를 즉시 +1/-1 처리
`getBookmarkedCountBySpot(spotId)`는 특정 스팟의 찜 받은 개수

<br>

## 관련 이슈
- Refs #59 

<br>