### PR TITLE
Refactor(api): REST API 경로를 RESTful 계층 구조로 개선

### DIFF
--- a/src/main/java/com/gemmap/gemmap/bookmark/presentation/BookmarkController.java
+++ b/src/main/java/com/gemmap/gemmap/bookmark/presentation/BookmarkController.java
@@ -6,12 +6,11 @@ import com.gemmap.gemmap.shared.common.annotation.UserId;
 import com.gemmap.gemmap.shared.common.enums.EAttractionLevel;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/api/v1/bookmarks")
+@RequestMapping("/api/v1/spots/{spotId}/bookmarks")
 @RequiredArgsConstructor
 public class BookmarkController {
 
@@ -19,11 +18,12 @@ public class BookmarkController {
 
     /**
      * 젬 찜하기
+     * POST /api/v1/spots/{spotId}/bookmarks
      */
-    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PostMapping
     public ResponseEntity<BookmarkCreateResponse> createBookmark(
             @UserId Long userId,
-            @RequestParam Long spotId,
+            @PathVariable Long spotId,
             @RequestParam EAttractionLevel attractionLevel
     ){
         return ResponseEntity.status(HttpStatus.CREATED)
@@ -32,8 +32,9 @@ public class BookmarkController {
 
     /**
      * 찜하기 취소
+     * DELETE /api/v1/spots/{spotId}/bookmarks
      */
-    @DeleteMapping("/{spotId}")
+    @DeleteMapping
     public ResponseEntity<Void> deleteBookmark(
             @UserId Long userId,
             @PathVariable Long spotId

--- a/src/main/java/com/gemmap/gemmap/checkin/application/dto/request/CheckinCreateRequest.java
+++ b/src/main/java/com/gemmap/gemmap/checkin/application/dto/request/CheckinCreateRequest.java
@@ -5,7 +5,6 @@ import com.gemmap.gemmap.shared.common.enums.ERecommendationLevel;
 import java.math.BigDecimal;
 
 public record CheckinCreateRequest(
-        Long spotId,
         ERecommendationLevel recommendationLevel,
         String takenAt,
         BigDecimal latitude,

--- a/src/main/java/com/gemmap/gemmap/checkin/application/service/CheckinService.java
+++ b/src/main/java/com/gemmap/gemmap/checkin/application/service/CheckinService.java
@@ -62,13 +62,13 @@ public class CheckinService {
      * 위치 검증은 프론트엔드에서 수행. 백엔드는 좌표를 수신하여 spot_photos에 저장만 함.
      */
     @Transactional
-    public CheckinCreateResponse createCheckin(Long userId, CheckinCreateRequest req, MultipartFile file) {
+    public CheckinCreateResponse createCheckin(Long userId, Long spotId, CheckinCreateRequest req, MultipartFile file) {
         // 1) 사용자 조회
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CommonException(ErrorCode.USER_NOT_FOUND));
 
         // 2) 스팟 조회
-        Spot spot = spotRepository.findById(req.spotId())
+        Spot spot = spotRepository.findById(spotId)
                 .orElseThrow(() -> new CommonException(ErrorCode.SPOT_NOT_FOUND));
 
         // 3) 중복 체크인 확인

--- a/src/main/java/com/gemmap/gemmap/checkin/presentation/CheckinController.java
+++ b/src/main/java/com/gemmap/gemmap/checkin/presentation/CheckinController.java
@@ -15,7 +15,7 @@ import org.springframework.web.multipart.MultipartFile;
 import java.math.BigDecimal;
 
 @RestController
-@RequestMapping("/api/v1/checkins")
+@RequestMapping("/api/v1/spots/{spotId}/checkins")
 @RequiredArgsConstructor
 public class CheckinController {
 
@@ -23,12 +23,12 @@ public class CheckinController {
 
     /**
      * 젬 획득하기 (체크인)
-     * POST /api/v1/checkins
+     * POST /api/v1/spots/{spotId}/checkins
      */
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<CheckinCreateResponse> createCheckin(
             @UserId Long userId,
-            @RequestParam Long spotId,
+            @PathVariable Long spotId,
             @RequestParam MultipartFile file,
             @RequestParam ERecommendationLevel recommendationLevel,
             @RequestParam(required = false) String takenAt,
@@ -42,18 +42,18 @@ public class CheckinController {
             @RequestParam(required = false) BigDecimal focalLength
     ) {
         CheckinCreateRequest request = new CheckinCreateRequest(
-                spotId, recommendationLevel, takenAt, latitude, longitude,
+                recommendationLevel, takenAt, latitude, longitude,
                 cameraMake, cameraModel, aperture, shutterSpeed, iso, focalLength
         );
         return ResponseEntity.status(HttpStatus.CREATED)
-                .body(checkinService.createCheckin(userId, request, file));
+                .body(checkinService.createCheckin(userId, spotId, request, file));
     }
 
     /**
      * 체크인 취소
-     * DELETE /api/v1/checkins/{spotId}
+     * DELETE /api/v1/spots/{spotId}/checkins
      */
-    @DeleteMapping("/{spotId}")
+    @DeleteMapping
     public ResponseEntity<Void> deleteCheckin(
             @UserId Long userId,
             @PathVariable Long spotId

--- a/src/main/java/com/gemmap/gemmap/shared/common/constants/Constant.java
+++ b/src/main/java/com/gemmap/gemmap/shared/common/constants/Constant.java
@@ -41,9 +41,7 @@ public class Constant {
     public static final String[] USER_URLS = {
             "/api/v1/users/**",
             "/api/v1/spots/**",
-            "/api/v1/markers/**",
-            "/api/v1/bookmarks/**",
-            "/api/v1/checkins/**"
+            "/api/v1/markers/**"
     };
 
     // 관리자만 접근 가능한 경로

--- a/src/main/java/com/gemmap/gemmap/spot/presentation/SpotController.java
+++ b/src/main/java/com/gemmap/gemmap/spot/presentation/SpotController.java
@@ -62,11 +62,12 @@ public class SpotController {
 
     /**
      * 스팟 삭제
+     * DELETE /api/v1/spots/{spotId}
      */
-    @DeleteMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @DeleteMapping("/{spotId}")
     public ResponseEntity<Void> delete(
             @UserId Long userId,
-            @RequestParam Long spotId
+            @PathVariable Long spotId
     ) {
         spotService.delete(userId, spotId);
         return ResponseEntity.noContent().build();


### PR DESCRIPTION
## 요약
체크인/북마크 엔드포인트를 `/spots/{spotId}` 하위 경로로 이동하여 리소스 간 계층 관계를 URL에 반영함

<br>

## 작업 내용
- `CheckinController`: `/api/v1/checkins` → `/api/v1/spots/{spotId}/checkins`
- `BookmarkController`: `/api/v1/bookmarks` → `/api/v1/spots/{spotId}/bookmarks`, `consumes = MULTIPART_FORM_DATA_VALUE` 제거
- `SpotController`: `DELETE /api/v1/spots` (`@RequestParam`) → `DELETE /api/v1/spots/{spotId}` (`@PathVariable`)
- `CheckinCreateRequest`: `spotId` 필드 제거 (Path Variable로 대체)
- `CheckinService.createCheckin`: `Long spotId` 파라미터 추가
- `Constant.USER_URLS`: `bookmarks/**`, `checkins/**` 제거 (`spots/**`로 커버)

<br>

## 참고 사항
- `BookmarkService` 시그니처는 이미 `spotId`를 직접 파라미터로 받고 있어 변경 없음
- `BookmarkController`의 `MediaType` import는 `consumes` 제거에 따라 함께 삭제

<br>

## 관련 이슈
- Closes #64

<br>