### PR TITLE
Feat(auth): 사진 정보 활용 동의 API 및 업로드 기능 동의 검증 추가

### DIFF
--- a/src/main/java/com/gemmap/gemmap/auth/application/dto/response/PhotoConsentResponse.java
+++ b/src/main/java/com/gemmap/gemmap/auth/application/dto/response/PhotoConsentResponse.java
@@ -1,0 +1,9 @@
+package com.gemmap.gemmap.auth.application.dto.response;
+
+public record PhotoConsentResponse(
+        boolean agreed
+) {
+    public static PhotoConsentResponse of(boolean agreed) {
+        return new PhotoConsentResponse(agreed);
+    }
+}

--- a/src/main/java/com/gemmap/gemmap/auth/application/service/AuthService.java
+++ b/src/main/java/com/gemmap/gemmap/auth/application/service/AuthService.java
@@ -3,6 +3,7 @@ package com.gemmap.gemmap.auth.application.service;
 import com.gemmap.gemmap.auth.application.dto.kakao.KakaoAccessTokenInfoResponse;
 import com.gemmap.gemmap.auth.application.dto.kakao.KakaoUserInfoResponse;
 import com.gemmap.gemmap.auth.application.dto.response.KakaoLoginResponseDto;
+import com.gemmap.gemmap.auth.application.dto.response.PhotoConsentResponse;
 import com.gemmap.gemmap.auth.application.dto.response.RegisterResponseDto;
 import com.gemmap.gemmap.auth.domain.entity.User;
 import com.gemmap.gemmap.auth.domain.repository.UserRepository;
@@ -17,10 +18,10 @@ import com.gemmap.gemmap.shared.common.enums.ERole;
 import com.gemmap.gemmap.shared.config.s3.S3Properties;
 import com.gemmap.gemmap.shared.exception.CommonException;
 import com.gemmap.gemmap.shared.exception.ErrorCode;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDate;
@@ -497,5 +498,33 @@ public class AuthService {
             log.error("로그아웃 처리 중 예상치 못한 오류: {}", e.getMessage(), e);
             throw new CommonException(ErrorCode.INTERNAL_SERVER_ERROR);
         }
+    }
+
+    /**
+     * 사진 정보 활용 동의 처리 (멱등)
+     * - 미동의 → 동의 처리 후 true 반환
+     * - 기동의 → 추가 처리 없이 true 반환 (409 아님)
+     */
+    @Transactional
+    public PhotoConsentResponse agreeToPhotoConsent(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CommonException(ErrorCode.USER_NOT_FOUND));
+
+        if (!user.hasPhotoConsentAgreed()) {
+            user.agreeToPhotoConsent();
+        }
+
+        return PhotoConsentResponse.of(user.hasPhotoConsentAgreed());
+    }
+
+    /**
+     * 사진 정보 활용 동의 상태 조회
+     */
+    @Transactional(readOnly = true)
+    public PhotoConsentResponse getPhotoConsentStatus(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CommonException(ErrorCode.USER_NOT_FOUND));
+
+        return PhotoConsentResponse.of(user.hasPhotoConsentAgreed());
     }
 }

--- a/src/main/java/com/gemmap/gemmap/auth/domain/entity/User.java
+++ b/src/main/java/com/gemmap/gemmap/auth/domain/entity/User.java
@@ -13,6 +13,7 @@ import org.hibernate.annotations.DynamicUpdate;
 import org.hibernate.annotations.SQLDelete;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.ZoneId;
 
 /**
@@ -62,6 +63,9 @@ public class User {
 
     @Column(name = "delete_date")
     private LocalDate deleteDate;
+
+    @Column(name = "photo_consent_agreed_at")
+    private LocalDateTime photoConsentAgreedAt;
 
     /* User Info */
 
@@ -166,5 +170,13 @@ public class User {
     public void recoverUser() {
         this.isDeleted = false;
         this.deleteDate = null;
+    }
+
+    public void agreeToPhotoConsent() {
+        this.photoConsentAgreedAt = LocalDateTime.now(KST);
+    }
+
+    public boolean hasPhotoConsentAgreed() {
+        return this.photoConsentAgreedAt != null;
     }
 }

--- a/src/main/java/com/gemmap/gemmap/auth/presentation/AuthController.java
+++ b/src/main/java/com/gemmap/gemmap/auth/presentation/AuthController.java
@@ -1,6 +1,7 @@
 package com.gemmap.gemmap.auth.presentation;
 
 import com.gemmap.gemmap.auth.application.dto.response.KakaoLoginResponseDto;
+import com.gemmap.gemmap.auth.application.dto.response.PhotoConsentResponse;
 import com.gemmap.gemmap.auth.application.dto.response.RegisterResponseDto;
 import com.gemmap.gemmap.auth.application.service.AuthService;
 import com.gemmap.gemmap.shared.common.annotation.UserId;
@@ -85,5 +86,23 @@ public class AuthController {
 
         authService.logout(userId);
         return ResponseEntity.noContent().build();
+    }
+
+    /**
+     * 사진 정보 활용 동의 처리
+     * POST /api/v1/auth/photo-consent
+     */
+    @PostMapping("/photo-consent")
+    public ResponseEntity<PhotoConsentResponse> agreeToPhotoConsent(@UserId Long userId) {
+        return ResponseEntity.ok(authService.agreeToPhotoConsent(userId));
+    }
+
+    /**
+     * 사진 정보 활용 동의 상태 조회
+     * GET /api/v1/auth/photo-consent
+     */
+    @GetMapping("/photo-consent")
+    public ResponseEntity<PhotoConsentResponse> getPhotoConsentStatus(@UserId Long userId) {
+        return ResponseEntity.ok(authService.getPhotoConsentStatus(userId));
     }
 }

--- a/src/main/java/com/gemmap/gemmap/checkin/application/service/CheckinService.java
+++ b/src/main/java/com/gemmap/gemmap/checkin/application/service/CheckinService.java
@@ -56,8 +56,8 @@ public class CheckinService {
      * 젬 획득하기 (체크인)
      *
      * 처리 순서:
-     * 1) 사용자/스팟 조회 → 2) 중복 확인 → 3) 파일 검증
-     * → 4) S3 업로드 → 5) spot_photos 저장 → 6) spot_checkins 저장 → 7) 응답
+     * 1) 사용자 조회 → 2) 동의 확인 → 3) 스팟 조회 → 4) 중복 확인 → 5) 파일 검증
+     * → 6) S3 업로드 → 7) spot_photos 저장 → 8) spot_checkins 저장 → 9) 응답
      *
      * 위치 검증은 프론트엔드에서 수행. 백엔드는 좌표를 수신하여 spot_photos에 저장만 함.
      */
@@ -67,19 +67,24 @@ public class CheckinService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CommonException(ErrorCode.USER_NOT_FOUND));
 
-        // 2) 스팟 조회
+        // 2) 사진 정보 활용 동의 확인
+        if (!user.hasPhotoConsentAgreed()) {
+            throw new CommonException(ErrorCode.PHOTO_CONSENT_REQUIRED);
+        }
+
+        // 3) 스팟 조회
         Spot spot = spotRepository.findById(spotId)
                 .orElseThrow(() -> new CommonException(ErrorCode.SPOT_NOT_FOUND));
 
-        // 3) 중복 체크인 확인
+        // 4) 중복 체크인 확인
         if (spotCheckinRepository.existsByUserAndSpot(user, spot)) {
             throw new CommonException(ErrorCode.CHECKIN_ALREADY_EXISTS);
         }
 
-        // 4) 파일 검증
+        // 5) 파일 검증
         spotFileValidator.validateImage(file);
 
-        // 5) S3 업로드 (키 규칙 예: spots/yyyy/MM/uuid.ext)
+        // 6) S3 업로드 (키 규칙 예: spots/yyyy/MM/uuid.ext)
         String key = S3FileUtils.buildKey(checkinBasePath, file.getOriginalFilename());
         String fileUrl;
         try {
@@ -93,7 +98,7 @@ public class CheckinService {
         }
 
         try {
-            // 6) spot_photos 저장
+            // 7) spot_photos 저장
             SpotPhoto photo = SpotPhoto.builder()
                     .spot(spot)
                     .user(user)
@@ -112,7 +117,7 @@ public class CheckinService {
                     .build();
             spotPhotoRepository.save(photo);
 
-            // 7) spot_checkins 저장 (photo_id FK 연결)
+            // 8) spot_checkins 저장 (photo_id FK 연결)
             SpotCheckin checkin = SpotCheckin.builder()
                     .user(user)
                     .spot(spot)
@@ -121,7 +126,7 @@ public class CheckinService {
                     .build();
             spotCheckinRepository.save(checkin);
 
-            // 8) 응답
+            // 9) 응답
             return CheckinCreateResponse.of(checkin, fileUrl);
         } catch (RuntimeException ex) {
             // 보상 트랜잭션: DB 저장 실패 시 업로드된 S3 객체 삭제

--- a/src/main/java/com/gemmap/gemmap/shared/exception/ErrorCode.java
+++ b/src/main/java/com/gemmap/gemmap/shared/exception/ErrorCode.java
@@ -32,6 +32,7 @@ public enum ErrorCode {
     // 403 Forbidden
     ACCESS_DENIED(40300, HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
     INVALID_ROLE(40301, HttpStatus.FORBIDDEN, "요청한 리소스에 접근할 수 있는 권한이 없습니다."),
+    PHOTO_CONSENT_REQUIRED(40302, HttpStatus.FORBIDDEN, "사진 정보 활용 동의가 필요합니다."),
 
     // 405 Method Not Allowed
     METHOD_NOT_ALLOWED(40500, HttpStatus.METHOD_NOT_ALLOWED, "허용되지 않은 HTTP 메서드입니다."),

--- a/src/main/java/com/gemmap/gemmap/spot/application/service/SpotService.java
+++ b/src/main/java/com/gemmap/gemmap/spot/application/service/SpotService.java
@@ -65,11 +65,16 @@ public class SpotService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CommonException(ErrorCode.USER_NOT_FOUND));
 
-        // 2) 요청 검증 (빠른 실패 우선: 좌표 검증 -> 파일 검증)
+        // 2) 사진 정보 활용 동의 확인
+        if (!user.hasPhotoConsentAgreed()) {
+            throw new CommonException(ErrorCode.PHOTO_CONSENT_REQUIRED);
+        }
+
+        // 3) 요청 검증 (빠른 실패 우선: 좌표 검증 -> 파일 검증)
         validateCoordinates(req.latitude(), req.longitude());
         spotFileValidator.validateImage(file);
 
-        // 3) 업로드 (키 규칙 예: spots/yyyy/MM/uuid.ext)
+        // 4) 업로드 (키 규칙 예: spots/yyyy/MM/uuid.ext)
         String key = S3FileUtils.buildKey(spotBasePath, file.getOriginalFilename());
         String fileUrl;
         try {
@@ -82,7 +87,7 @@ public class SpotService {
         }
 
         try {
-            // 4) spots 저장
+            // 5) spots 저장
             Spot spot = spotRepository.save(
                 Spot.builder()
                     .user(user)
@@ -97,7 +102,7 @@ public class SpotService {
                     .build()
             );
 
-            // 5) spot_photos 저장 (type=SPOT, fileUrl 직접 저장, user 저장)
+            // 6) spot_photos 저장 (type=SPOT, fileUrl 직접 저장, user 저장)
             SpotPhoto photo = SpotPhoto.builder()
                 .spot(spot)
                 .user(user)
@@ -116,7 +121,7 @@ public class SpotService {
                 .build();
             spotPhotoRepository.save(photo);
 
-            // 6) 응답
+            // 7) 응답
             return SpotCreateResponse.builder()
                 .spotId(spot.getId())
                 .fileUrl(fileUrl)

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -43,3 +43,5 @@ s3:
     name: "kr-1"
   bucket: "test-bucket"
   base-path: "test/"
+  spot-base-path: "test/spots/"
+  checkin-base-path: "test/checkins/"

--- a/src/test/java/com/gemmap/gemmap/spot/application/service/SpotServiceTest.java
+++ b/src/test/java/com/gemmap/gemmap/spot/application/service/SpotServiceTest.java
@@ -97,6 +97,7 @@ class SpotServiceTest {
 
     private void mockUserFound() {
         given(userRepository.findById(TEST_USER_ID)).willReturn(Optional.of(testUser));
+        given(testUser.hasPhotoConsentAgreed()).willReturn(true);
     }
 
     private void mockS3UploadSuccess() throws Exception {


### PR DESCRIPTION
## 요약
체크인/스팟 생성 시 사진 EXIF 위치정보 활용에 대한 사용자 동의를 1회 받고,
서버에서 동의 상태를 저장/조회/검증하는 기능을 구현함

<br>

## 작업 내용
- `User` 엔티티에 `photoConsentAgreedAt` 필드 및 도메인 메서드 추가
- `PHOTO_CONSENT_REQUIRED(40302, 403)` 에러 코드 추가
- `POST /api/v1/auth/photo-consent` - 동의 처리 (멱등, 최초 동의 시각 보존)
- `GET /api/v1/auth/photo-consent` - 동의 상태 조회
- `SpotService.create()`, `CheckinService.createCheckin()` 진입 시 미동의 사용자 차단
- `SpotServiceTest` mock 수정, `application-test.yml` 누락 프로퍼티 보완

<br>

## 참고 사항
- 동의는 1회성으로 취소/재동의 불가 (1차 출시 기준)
- 이미 동의한 사용자가 재요청해도 409 없이 200 반환 (멱등 설계)
- DB 마이그레이션 필요: `ALTER TABLE users ADD COLUMN photo_consent_agreed_at DATETIME NULL`

<br>

## 관련 이슈
- Refs #66 

<br>