### PR TITLE
Feat(report): 스팟 신고 접수 API 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,15 @@ src/main/resources/certs
 # Claude Code
 .claude/
 
+# Cursor
+.cursor/
+
+# Agent
+.agents/
+AGENTS.md
+
+package-lock.json
+
 nul
 
 # Document

--- a/src/main/java/com/gemmap/gemmap/report/application/dto/request/SpotReportRequest.java
+++ b/src/main/java/com/gemmap/gemmap/report/application/dto/request/SpotReportRequest.java
@@ -1,0 +1,11 @@
+package com.gemmap.gemmap.report.application.dto.request;
+
+import com.gemmap.gemmap.shared.common.enums.EReportReason;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record SpotReportRequest(
+        @NotNull EReportReason reason,
+        @Size(max = 100) String content
+) {
+}

--- a/src/main/java/com/gemmap/gemmap/report/application/dto/response/SpotReportResponse.java
+++ b/src/main/java/com/gemmap/gemmap/report/application/dto/response/SpotReportResponse.java
@@ -1,0 +1,16 @@
+package com.gemmap.gemmap.report.application.dto.response;
+
+import com.gemmap.gemmap.report.domain.entity.SpotReport;
+import lombok.Builder;
+
+@Builder
+public record SpotReportResponse(
+        Long reportId
+) {
+
+    public static SpotReportResponse of(SpotReport report) {
+        return SpotReportResponse.builder()
+                .reportId(report.getId())
+                .build();
+    }
+}

--- a/src/main/java/com/gemmap/gemmap/report/application/service/ReportService.java
+++ b/src/main/java/com/gemmap/gemmap/report/application/service/ReportService.java
@@ -1,0 +1,83 @@
+package com.gemmap.gemmap.report.application.service;
+
+import com.gemmap.gemmap.auth.domain.entity.User;
+import com.gemmap.gemmap.auth.domain.repository.UserRepository;
+import com.gemmap.gemmap.report.application.dto.request.SpotReportRequest;
+import com.gemmap.gemmap.report.application.dto.response.SpotReportResponse;
+import com.gemmap.gemmap.report.domain.entity.SpotReport;
+import com.gemmap.gemmap.report.domain.repository.SpotReportRepository;
+import com.gemmap.gemmap.shared.common.enums.EReportReason;
+import com.gemmap.gemmap.shared.exception.CommonException;
+import com.gemmap.gemmap.shared.exception.ErrorCode;
+import com.gemmap.gemmap.spot.domain.entity.Spot;
+import com.gemmap.gemmap.spot.domain.repository.SpotRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+@Service
+@RequiredArgsConstructor
+public class ReportService {
+
+    private final UserRepository userRepository;
+    private final SpotRepository spotRepository;
+    private final SpotReportRepository spotReportRepository;
+
+    /**
+     * 스팟 신고 접수
+     */
+    @Transactional
+    public SpotReportResponse createReport(Long userId, Long spotId, SpotReportRequest request) {
+        // 사용자 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CommonException(ErrorCode.USER_NOT_FOUND));
+
+        // 스팟 조회
+        Spot spot = spotRepository.findById(spotId)
+                .orElseThrow(() -> new CommonException(ErrorCode.SPOT_NOT_FOUND));
+
+        // 본인 스팟 신고 방지
+        if (spot.getUser().getId().equals(userId)) {
+            throw new CommonException(ErrorCode.CANNOT_REPORT_OWN_SPOT);
+        }
+
+        // 중복 신고 확인
+        if (spotReportRepository.existsByUserAndSpot(user, spot)) {
+            throw new CommonException(ErrorCode.REPORT_ALREADY_EXISTS);
+        }
+
+        // 저장 (DataIntegrityViolationException: 동시 요청으로 인한 유니크 제약 위반 방어)
+        SpotReport report = SpotReport.builder()
+                .user(user)
+                .spot(spot)
+                .reason(request.reason())
+                .content(validateAndNormalizeContent(request.reason(), request.content()))
+                .build();
+
+        try {
+            return SpotReportResponse.of(spotReportRepository.save(report));
+        } catch (DataIntegrityViolationException ex) {
+            throw new CommonException(ErrorCode.REPORT_ALREADY_EXISTS);
+        }
+    }
+
+    /**
+     * 신고 사유에 맞는 content 필수 여부와 저장값 형식을 함께 정리한다.
+     */
+    private String validateAndNormalizeContent(EReportReason reason, String content) {
+        // OTHER가 아닌 사유
+        if (reason != EReportReason.OTHER) {
+            return null; // content를 항상 null로 반환
+        }
+
+        // OTHER 사유 + content 없음(null / 빈 문자열 / 공백만)
+        if (!StringUtils.hasText(content)) {
+            throw new CommonException(ErrorCode.REPORT_CONTENT_REQUIRED);
+        }
+
+        // OTHER 사유 + content 있음
+        return content.trim();
+    }
+}

--- a/src/main/java/com/gemmap/gemmap/report/domain/entity/SpotReport.java
+++ b/src/main/java/com/gemmap/gemmap/report/domain/entity/SpotReport.java
@@ -1,0 +1,71 @@
+package com.gemmap.gemmap.report.domain.entity;
+
+import com.gemmap.gemmap.auth.domain.entity.User;
+import com.gemmap.gemmap.shared.common.enums.EReportReason;
+import com.gemmap.gemmap.spot.domain.entity.Spot;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "spot_reports",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_spot_reports_user_spot",
+                columnNames = {"user_id", "spot_id"}
+        ))
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class SpotReport {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "spot_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private Spot spot;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "reason", nullable = false, length = 50)
+    private EReportReason reason;
+
+    @Column(name = "content", length = 100)
+    private String content;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Builder
+    public SpotReport(User user, Spot spot, EReportReason reason, String content) {
+        this.user = user;
+        this.spot = spot;
+        this.reason = reason;
+        this.content = content;
+    }
+}

--- a/src/main/java/com/gemmap/gemmap/report/domain/repository/SpotReportRepository.java
+++ b/src/main/java/com/gemmap/gemmap/report/domain/repository/SpotReportRepository.java
@@ -1,0 +1,11 @@
+package com.gemmap.gemmap.report.domain.repository;
+
+import com.gemmap.gemmap.auth.domain.entity.User;
+import com.gemmap.gemmap.report.domain.entity.SpotReport;
+import com.gemmap.gemmap.spot.domain.entity.Spot;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SpotReportRepository extends JpaRepository<SpotReport, Long> {
+
+    boolean existsByUserAndSpot(User user, Spot spot);
+}

--- a/src/main/java/com/gemmap/gemmap/report/presentation/ReportController.java
+++ b/src/main/java/com/gemmap/gemmap/report/presentation/ReportController.java
@@ -1,0 +1,37 @@
+package com.gemmap.gemmap.report.presentation;
+
+import com.gemmap.gemmap.report.application.dto.request.SpotReportRequest;
+import com.gemmap.gemmap.report.application.dto.response.SpotReportResponse;
+import com.gemmap.gemmap.report.application.service.ReportService;
+import com.gemmap.gemmap.shared.common.annotation.UserId;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/spots/{spotId}/reports")
+@RequiredArgsConstructor
+public class ReportController {
+
+    private final ReportService reportService;
+
+    /**
+     * 스팟 신고
+     * POST /api/v1/spots/{spotId}/reports
+     */
+    @PostMapping
+    public ResponseEntity<SpotReportResponse> createReport(
+            @UserId Long userId,
+            @PathVariable Long spotId,
+            @Valid @RequestBody SpotReportRequest request
+    ) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(reportService.createReport(userId, spotId, request));
+    }
+}

--- a/src/main/java/com/gemmap/gemmap/shared/common/enums/EReportReason.java
+++ b/src/main/java/com/gemmap/gemmap/shared/common/enums/EReportReason.java
@@ -1,0 +1,8 @@
+package com.gemmap.gemmap.shared.common.enums;
+
+public enum EReportReason {
+    LOCATION_MISMATCH,    // 사진과 입력된 위치가 달라요
+    INAPPROPRIATE_PHOTO,  // 부적절한 사진이에요
+    UNAUTHORIZED_PHOTO,   // 타인의 사진을 무단으로 사용했어요
+    OTHER                 // 기타 (content 필수)
+}

--- a/src/main/java/com/gemmap/gemmap/shared/exception/ErrorCode.java
+++ b/src/main/java/com/gemmap/gemmap/shared/exception/ErrorCode.java
@@ -33,6 +33,7 @@ public enum ErrorCode {
     ACCESS_DENIED(40300, HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
     INVALID_ROLE(40301, HttpStatus.FORBIDDEN, "요청한 리소스에 접근할 수 있는 권한이 없습니다."),
     PHOTO_CONSENT_REQUIRED(40302, HttpStatus.FORBIDDEN, "사진 정보 활용 동의가 필요합니다."),
+    CANNOT_REPORT_OWN_SPOT(40303, HttpStatus.FORBIDDEN, "본인의 젬은 신고할 수 없습니다."),
 
     // 405 Method Not Allowed
     METHOD_NOT_ALLOWED(40500, HttpStatus.METHOD_NOT_ALLOWED, "허용되지 않은 HTTP 메서드입니다."),
@@ -54,6 +55,7 @@ public enum ErrorCode {
     ALREADY_REGISTERED_USER(40902, HttpStatus.CONFLICT, "이미 회원가입이 완료된 사용자입니다."),
     BOOKMARK_ALREADY_EXISTS(40903, HttpStatus.CONFLICT, "이미 찜한 젬입니다."),
     CHECKIN_ALREADY_EXISTS(40904, HttpStatus.CONFLICT, "이미 체크인한 젬입니다."),
+    REPORT_ALREADY_EXISTS(40905, HttpStatus.CONFLICT, "이미 신고한 젬입니다."),
 
     // 500 Internal Server Error
     INTERNAL_SERVER_ERROR(50000, HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다."),
@@ -69,6 +71,7 @@ public enum ErrorCode {
     FILE_UPLOAD_FAILED(50020, HttpStatus.INTERNAL_SERVER_ERROR, "파일 업로드에 실패했습니다."),
     INVALID_FILE_FORMAT(40010, HttpStatus.BAD_REQUEST, "지원하지 않는 파일 형식입니다."),
     FILE_SIZE_EXCEEDED(40011, HttpStatus.BAD_REQUEST, "파일 크기가 너무 큽니다."),
+    REPORT_CONTENT_REQUIRED(40012, HttpStatus.BAD_REQUEST, "'기타' 사유 선택 시 신고 내용을 입력해야 합니다."),
 
     // OAuth2 관련 에러 (502 Bad Gateway - 외부 서비스 오류)
     KAKAO_TOKEN_REQUEST_FAILED(50201, HttpStatus.BAD_GATEWAY, "카카오 토큰 요청에 실패했습니다."),

--- a/src/test/java/com/gemmap/gemmap/report/application/service/ReportServiceTest.java
+++ b/src/test/java/com/gemmap/gemmap/report/application/service/ReportServiceTest.java
@@ -1,0 +1,184 @@
+package com.gemmap.gemmap.report.application.service;
+
+import com.gemmap.gemmap.auth.domain.entity.User;
+import com.gemmap.gemmap.auth.domain.repository.UserRepository;
+import com.gemmap.gemmap.report.application.dto.request.SpotReportRequest;
+import com.gemmap.gemmap.report.application.dto.response.SpotReportResponse;
+import com.gemmap.gemmap.report.domain.entity.SpotReport;
+import com.gemmap.gemmap.report.domain.repository.SpotReportRepository;
+import com.gemmap.gemmap.shared.common.enums.EReportReason;
+import com.gemmap.gemmap.shared.exception.CommonException;
+import com.gemmap.gemmap.shared.exception.ErrorCode;
+import com.gemmap.gemmap.spot.domain.entity.Spot;
+import com.gemmap.gemmap.spot.domain.repository.SpotRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+
+@ExtendWith(MockitoExtension.class)
+class ReportServiceTest {
+
+    private static final Long TEST_USER_ID = 1L;
+    private static final Long TEST_SPOT_ID = 10L;
+    private static final Long OTHER_USER_ID = 2L;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private SpotRepository spotRepository;
+
+    @Mock
+    private SpotReportRepository spotReportRepository;
+
+    @InjectMocks
+    private ReportService reportService;
+
+    private User user;
+    private User owner;
+    private Spot spot;
+
+    @BeforeEach
+    void setUp() {
+        user = mock(User.class);
+        owner = mock(User.class);
+        spot = mock(Spot.class);
+
+        lenient().when(user.getId()).thenReturn(TEST_USER_ID);
+        lenient().when(owner.getId()).thenReturn(OTHER_USER_ID);
+        lenient().when(spot.getId()).thenReturn(TEST_SPOT_ID);
+        lenient().when(spot.getUser()).thenReturn(owner);
+    }
+
+    private void mockUserAndSpotFound() {
+        given(userRepository.findById(TEST_USER_ID)).willReturn(Optional.of(user));
+        given(spotRepository.findById(TEST_SPOT_ID)).willReturn(Optional.of(spot));
+    }
+
+    @Nested
+    @DisplayName("신고 생성")
+    class CreateReport {
+
+        @Test
+        @DisplayName("OTHER 사유는 content를 trim 후 저장한다")
+        void createReport_trimsOtherContent() {
+            mockUserAndSpotFound();
+            given(spotReportRepository.existsByUserAndSpot(user, spot)).willReturn(false);
+
+            ArgumentCaptor<SpotReport> reportCaptor = ArgumentCaptor.forClass(SpotReport.class);
+            SpotReport savedReport = SpotReport.builder()
+                    .user(user)
+                    .spot(spot)
+                    .reason(EReportReason.OTHER)
+                    .content("신고 내용")
+                    .build();
+            given(spotReportRepository.save(reportCaptor.capture())).willReturn(savedReport);
+
+            SpotReportResponse response = reportService.createReport(
+                    TEST_USER_ID,
+                    TEST_SPOT_ID,
+                    new SpotReportRequest(EReportReason.OTHER, "  신고 내용  ")
+            );
+
+            assertThat(reportCaptor.getValue().getContent()).isEqualTo("신고 내용");
+            assertThat(response.reportId()).isNull();
+        }
+
+        @Test
+        @DisplayName("OTHER가 아닌 사유는 content를 null로 정리한다")
+        void createReport_nonOtherReasonDropsContent() {
+            mockUserAndSpotFound();
+            given(spotReportRepository.existsByUserAndSpot(user, spot)).willReturn(false);
+
+            ArgumentCaptor<SpotReport> reportCaptor = ArgumentCaptor.forClass(SpotReport.class);
+            given(spotReportRepository.save(reportCaptor.capture()))
+                    .willAnswer(invocation -> invocation.getArgument(0));
+
+            reportService.createReport(
+                    TEST_USER_ID,
+                    TEST_SPOT_ID,
+                    new SpotReportRequest(EReportReason.LOCATION_MISMATCH, "  무시될 내용  ")
+            );
+
+            assertThat(reportCaptor.getValue().getContent()).isNull();
+        }
+
+        @Test
+        @DisplayName("본인 스팟 신고는 CANNOT_REPORT_OWN_SPOT 예외")
+        void createReport_ownSpotThrowsForbidden() {
+            given(owner.getId()).willReturn(TEST_USER_ID);
+            mockUserAndSpotFound();
+
+            assertThatThrownBy(() -> reportService.createReport(
+                    TEST_USER_ID,
+                    TEST_SPOT_ID,
+                    new SpotReportRequest(EReportReason.LOCATION_MISMATCH, null)
+            ))
+                    .isInstanceOf(CommonException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.CANNOT_REPORT_OWN_SPOT);
+        }
+
+        @Test
+        @DisplayName("OTHER 사유에 content가 없으면 REPORT_CONTENT_REQUIRED 예외")
+        void createReport_blankOtherContentThrowsBadRequest() {
+            mockUserAndSpotFound();
+            given(spotReportRepository.existsByUserAndSpot(user, spot)).willReturn(false);
+
+            assertThatThrownBy(() -> reportService.createReport(
+                    TEST_USER_ID,
+                    TEST_SPOT_ID,
+                    new SpotReportRequest(EReportReason.OTHER, "   ")
+            ))
+                    .isInstanceOf(CommonException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.REPORT_CONTENT_REQUIRED);
+        }
+
+        @Test
+        @DisplayName("중복 신고는 REPORT_ALREADY_EXISTS 예외")
+        void createReport_duplicateThrowsConflict() {
+            mockUserAndSpotFound();
+            given(spotReportRepository.existsByUserAndSpot(user, spot)).willReturn(true);
+
+            assertThatThrownBy(() -> reportService.createReport(
+                    TEST_USER_ID,
+                    TEST_SPOT_ID,
+                    new SpotReportRequest(EReportReason.LOCATION_MISMATCH, null)
+            ))
+                    .isInstanceOf(CommonException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.REPORT_ALREADY_EXISTS);
+        }
+
+        @Test
+        @DisplayName("DB 유니크 제약 충돌도 REPORT_ALREADY_EXISTS로 변환한다")
+        void createReport_dataIntegrityViolationThrowsConflict() {
+            mockUserAndSpotFound();
+            given(spotReportRepository.existsByUserAndSpot(user, spot)).willReturn(false);
+            given(spotReportRepository.save(any(SpotReport.class)))
+                    .willThrow(new DataIntegrityViolationException("duplicate"));
+
+            assertThatThrownBy(() -> reportService.createReport(
+                    TEST_USER_ID,
+                    TEST_SPOT_ID,
+                    new SpotReportRequest(EReportReason.LOCATION_MISMATCH, null)
+            ))
+                    .isInstanceOf(CommonException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.REPORT_ALREADY_EXISTS);
+        }
+    }
+}


### PR DESCRIPTION
## 요약
젬 탐색 스팟 상세 화면에서 부적절한 스팟을 신고할 수 있는 API를 구현함  
이번 스프린트 범위는 신고 접수 저장까지, 관리자 처리 기능은 후속 스프린트로 분리함  

<br>

## 작업 내용
- `POST /api/v1/spots/{spotId}/reports` 엔드포인트 추가
- `com.gemmap.gemmap.report` 패키지 신규 구성 (entity / repository / service / controller / dto)
- 신고 사유 Enum `EReportReason` 추가 (LOCATION_MISMATCH, INAPPROPRIATE_PHOTO, UNAUTHORIZED_PHOTO, OTHER)
- 본인 스팟 신고 방지 (`CANNOT_REPORT_OWN_SPOT 40303`)
- 동일 사용자 중복 신고 방지 — 서비스 사전 확인 + DB 유니크 제약 이중 방어
- `DataIntegrityViolationException` catch로 동시 요청 시 응답 일관성 보장 (`REPORT_ALREADY_EXISTS 40905`)
- `reason=OTHER`일 때 `content` 조건부 필수 검증 (`REPORT_CONTENT_REQUIRED 40012`)
- `ErrorCode`에 40012, 40303, 40905 추가
- `ReportServiceTest` 단위 테스트 추가

<br>

## 참고 사항
- `content` 길이 제한(100자)은 DTO `@Size`, 조건부 필수는 서비스 레이어에서 각각 담당
- 현재 신고 타입이 `OTHER` 일 때 신고 사유(`content`)를 필수로 받음 (기획에 따라 변경될 수 있음)

<br>

## 관련 이슈
- Refs #68

<br>