### PR TITLE
Feat(auth): Apple 소셜 로그인 API 구현

### DIFF
--- a/.github/workflows/develop-cd.yml
+++ b/.github/workflows/develop-cd.yml
@@ -97,6 +97,7 @@ jobs:
               -e KAKAO_CLIENT_SECRET='${{ secrets.KAKAO_CLIENT_SECRET }}' \
               -e KAKAO_REDIRECT_URI='${{ secrets.KAKAO_REDIRECT_URI }}' \
               -e KAKAO_APP_ID='${{ secrets.KAKAO_APP_ID }}' \
+              -e APPLE_BUNDLE_ID='${{ secrets.APPLE_BUNDLE_ID }}' \
               \
               -e S3_ENDPOINT='${{ secrets.S3_ENDPOINT }}' \
               -e S3_REGION='${{ secrets.S3_REGION }}' \

--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,7 @@ nul
 
 # Document
 docs
+
+# Postman
+.postman/
+postman/

--- a/src/main/java/com/gemmap/gemmap/auth/application/dto/apple/AppleIdentityTokenClaims.java
+++ b/src/main/java/com/gemmap/gemmap/auth/application/dto/apple/AppleIdentityTokenClaims.java
@@ -1,0 +1,10 @@
+package com.gemmap.gemmap.auth.application.dto.apple;
+
+/**
+ * Apple Identity Token에서 파싱된 클레임 정보
+ */
+public record AppleIdentityTokenClaims(
+        String sub,
+        String email
+) {
+}

--- a/src/main/java/com/gemmap/gemmap/auth/application/dto/request/AppleLoginRequestDto.java
+++ b/src/main/java/com/gemmap/gemmap/auth/application/dto/request/AppleLoginRequestDto.java
@@ -1,0 +1,10 @@
+package com.gemmap.gemmap.auth.application.dto.request;
+
+/**
+ * Apple 로그인 요청 Body DTO
+ * name은 최초 로그인 시 클라이언트가 전달해야 한다.
+ */
+public record AppleLoginRequestDto(
+        String name
+) {
+}

--- a/src/main/java/com/gemmap/gemmap/auth/application/dto/response/SocialLoginResponseDto.java
+++ b/src/main/java/com/gemmap/gemmap/auth/application/dto/response/SocialLoginResponseDto.java
@@ -3,15 +3,15 @@ package com.gemmap.gemmap.auth.application.dto.response;
 import com.gemmap.gemmap.shared.common.enums.ERole;
 
 /**
- * 카카오 로그인 응답 DTO (단순화된 버전)
+ * 소셜 로그인 응답 DTO
  */
-public record KakaoLoginResponseDto(
+public record SocialLoginResponseDto(
         Long userId,                // 사용자 ID
         String role,                // 사용자 역할
         String accessToken,         // 서비스 JWT 액세스 토큰
         String refreshToken         // 서비스 JWT 리프레시 토큰
 ) {
-    public static KakaoLoginResponseDto of(Long userId, ERole role, String accessToken, String refreshToken) {
-        return new KakaoLoginResponseDto(userId, role.toString(), accessToken, refreshToken);
+    public static SocialLoginResponseDto of(Long userId, ERole role, String accessToken, String refreshToken) {
+        return new SocialLoginResponseDto(userId, role.toString(), accessToken, refreshToken);
     }
 }

--- a/src/main/java/com/gemmap/gemmap/auth/application/service/AppleLoginTransactionService.java
+++ b/src/main/java/com/gemmap/gemmap/auth/application/service/AppleLoginTransactionService.java
@@ -1,0 +1,91 @@
+package com.gemmap.gemmap.auth.application.service;
+
+import com.gemmap.gemmap.auth.application.dto.response.SocialLoginResponseDto;
+import com.gemmap.gemmap.auth.domain.entity.User;
+import com.gemmap.gemmap.auth.domain.repository.UserRepository;
+import com.gemmap.gemmap.auth.infrastructure.jwt.JwtTokenDto;
+import com.gemmap.gemmap.auth.infrastructure.jwt.JwtUtil;
+import com.gemmap.gemmap.shared.common.enums.EProvider;
+import com.gemmap.gemmap.shared.common.enums.ERole;
+import com.gemmap.gemmap.shared.exception.CommonException;
+import com.gemmap.gemmap.shared.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AppleLoginTransactionService {
+
+    private final UserRepository userRepository;
+    private final JwtUtil jwtUtil;
+
+    @Transactional
+    public SocialLoginResponseDto completeAppleLogin(String socialId, String email, String name) {
+        User user = findOrCreateAppleUser(socialId, email, name);
+
+        JwtTokenDto jwtTokenDto = jwtUtil.generateTokens(user.getId(), user.getRole());
+        user.updateRefreshToken(jwtTokenDto.getRefreshToken());
+        user.updateLoginStatus(true);
+
+        log.info("Apple 로그인 성공 - 사용자 ID: {}, 권한: {}", user.getId(), user.getRole());
+
+        return SocialLoginResponseDto.of(
+                user.getId(),
+                user.getRole(),
+                jwtTokenDto.getAccessToken(),
+                jwtTokenDto.getRefreshToken()
+        );
+    }
+
+    private User findOrCreateAppleUser(String socialId, String email, String name) {
+        if (socialId == null || socialId.trim().isEmpty()) {
+            throw new CommonException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+
+        return userRepository.findBySocialIdAndProvider(socialId, EProvider.APPLE)
+                .orElseGet(() -> createAppleUser(socialId, email, name));
+    }
+
+    private User createAppleUser(String socialId, String email, String name) {
+        validateAppleSignupInfo(email, name);
+
+        User newUser = User.builder()
+                .socialId(socialId)
+                .eProvider(EProvider.APPLE)
+                .role(ERole.GUEST)
+                .email(email)
+                .name(name)
+                .nickname(null)
+                .profileImage(null)
+                .gender(null)
+                .ageRange(null)
+                .birthday(null)
+                .birthyear(null)
+                .build();
+
+        try {
+            User savedUser = userRepository.save(newUser);
+            log.info("신규 Apple 사용자 생성 - 소셜 ID: {}, 사용자 ID: {}", socialId, savedUser.getId());
+            return savedUser;
+        } catch (DataIntegrityViolationException e) {
+            log.warn("Apple 사용자 동시 생성 충돌 - socialId: {}, provider: APPLE. 기존 사용자 재조회", socialId);
+            return userRepository.findBySocialIdAndProvider(socialId, EProvider.APPLE)
+                    .orElseThrow(() -> new CommonException(ErrorCode.DATABASE_ERROR));
+        } catch (CommonException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("Apple 사용자 생성 중 오류: {}", e.getMessage(), e);
+            throw new CommonException(ErrorCode.DATABASE_ERROR);
+        }
+    }
+
+    private void validateAppleSignupInfo(String email, String name) {
+        if (name == null || name.trim().isEmpty() || email == null || email.trim().isEmpty()) {
+            throw new CommonException(ErrorCode.APPLE_REQUIRED_USER_INFO_MISSING);
+        }
+    }
+}

--- a/src/main/java/com/gemmap/gemmap/auth/application/service/AuthService.java
+++ b/src/main/java/com/gemmap/gemmap/auth/application/service/AuthService.java
@@ -1,23 +1,25 @@
 package com.gemmap.gemmap.auth.application.service;
 
+import com.gemmap.gemmap.auth.application.dto.apple.AppleIdentityTokenClaims;
 import com.gemmap.gemmap.auth.application.dto.kakao.KakaoAccessTokenInfoResponse;
 import com.gemmap.gemmap.auth.application.dto.kakao.KakaoUserInfoResponse;
-import com.gemmap.gemmap.auth.application.dto.response.KakaoLoginResponseDto;
 import com.gemmap.gemmap.auth.application.dto.response.PhotoConsentResponse;
 import com.gemmap.gemmap.auth.application.dto.response.RegisterResponseDto;
+import com.gemmap.gemmap.auth.application.dto.response.SocialLoginResponseDto;
 import com.gemmap.gemmap.auth.domain.entity.User;
 import com.gemmap.gemmap.auth.domain.repository.UserRepository;
 import com.gemmap.gemmap.auth.infrastructure.jwt.JwtTokenDto;
 import com.gemmap.gemmap.auth.infrastructure.jwt.JwtUtil;
+import com.gemmap.gemmap.auth.infrastructure.oauth.AppleOAuth2Service;
 import com.gemmap.gemmap.auth.infrastructure.oauth.KakaoOAuth2Service;
-import com.gemmap.gemmap.shared.infrastructure.objectstorage.ObjectStorageService;
-import com.gemmap.gemmap.shared.infrastructure.objectstorage.S3UrlGenerator;
 import com.gemmap.gemmap.shared.common.constants.Constant;
 import com.gemmap.gemmap.shared.common.enums.EProvider;
 import com.gemmap.gemmap.shared.common.enums.ERole;
 import com.gemmap.gemmap.shared.config.s3.S3Properties;
 import com.gemmap.gemmap.shared.exception.CommonException;
 import com.gemmap.gemmap.shared.exception.ErrorCode;
+import com.gemmap.gemmap.shared.infrastructure.objectstorage.ObjectStorageService;
+import com.gemmap.gemmap.shared.infrastructure.objectstorage.S3UrlGenerator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -34,7 +36,7 @@ import java.util.UUID;
  * 인증 관련 비즈니스 로직을 처리하는 서비스 클래스
  *
  * 주요 기능:
- * - 소셜 로그인 (Kakao)
+ * - 소셜 로그인 (Kakao, Apple)
  * - 회원가입 (GUEST → USER 권한 전환)
  * - 토큰 갱신 (Access Token + Refresh Token Rotation)
  * - 로그아웃
@@ -49,6 +51,8 @@ public class AuthService {
     private final UserRepository userRepository;
     private final JwtUtil jwtUtil;
     private final KakaoOAuth2Service kakaoOAuth2Service;
+    private final AppleOAuth2Service appleOAuth2Service;
+    private final AppleLoginTransactionService appleLoginTransactionService;
     private final ObjectStorageService objectStorageService;
     private final S3UrlGenerator s3UrlGenerator;
     private final S3Properties s3Properties;
@@ -58,7 +62,7 @@ public class AuthService {
      * 모바일 앱에서 획득한 카카오 Access Token을 검증하고 서비스 JWT 발급
      */
     @Transactional
-    public KakaoLoginResponseDto authenticateWithKakaoAccessToken(String kakaoAccessToken) {
+    public SocialLoginResponseDto authenticateWithKakaoAccessToken(String kakaoAccessToken) {
         if (kakaoAccessToken == null || kakaoAccessToken.trim().isEmpty()) {
             throw new CommonException(ErrorCode.INVALID_INPUT_VALUE);
         }
@@ -87,7 +91,7 @@ public class AuthService {
 
             log.info("카카오 SDK 로그인 성공 - 사용자 ID: {}, 권한: {}", user.getId(), user.getRole());
 
-            return KakaoLoginResponseDto.of(
+            return SocialLoginResponseDto.of(
                     user.getId(),
                     user.getRole(),
                     jwtTokenDto.getAccessToken(),
@@ -98,6 +102,31 @@ public class AuthService {
             throw e;
         } catch (Exception e) {
             log.error("카카오 SDK 로그인 처리 중 예상치 못한 오류: {}", e.getMessage(), e);
+            throw new CommonException(ErrorCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    /**
+     * Apple Identity Token으로 인증 (모바일 SDK 방식)
+     * 외부 Apple 토큰 검증은 트랜잭션 밖에서 수행하고,
+     * DB 작업은 AppleLoginTransactionService로 위임한다.
+     */
+    public SocialLoginResponseDto authenticateWithAppleToken(String identityToken, String name) {
+        if (identityToken == null || identityToken.trim().isEmpty()) {
+            throw new CommonException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+
+        try {
+            AppleIdentityTokenClaims claims = appleOAuth2Service.validateAndExtractClaims(identityToken);
+            return appleLoginTransactionService.completeAppleLogin(
+                    claims.sub(),
+                    claims.email(),
+                    name
+            );
+        } catch (CommonException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("Apple 로그인 처리 중 예상치 못한 오류: {}", e.getMessage(), e);
             throw new CommonException(ErrorCode.INTERNAL_SERVER_ERROR);
         }
     }
@@ -428,7 +457,7 @@ public class AuthService {
      * 액세스 토큰 갱신
      */
     @Transactional
-    public KakaoLoginResponseDto refreshAccessToken(String refreshToken) {
+    public SocialLoginResponseDto refreshAccessToken(String refreshToken) {
         try {
             // Refresh Token 유효성 검증
             if (!jwtUtil.validateToken(refreshToken)) {
@@ -463,7 +492,7 @@ public class AuthService {
             log.info("토큰 갱신 완료 - 사용자 ID: {}, Refresh Token 갱신: {}",
                     user.getId(), shouldRotateRefreshToken);
 
-            return KakaoLoginResponseDto.of(
+            return SocialLoginResponseDto.of(
                     user.getId(),
                     user.getRole(),
                     newAccessToken,

--- a/src/main/java/com/gemmap/gemmap/auth/domain/entity/User.java
+++ b/src/main/java/com/gemmap/gemmap/auth/domain/entity/User.java
@@ -26,14 +26,22 @@ import java.time.ZoneId;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @DynamicUpdate
 @SQLDelete(sql = "UPDATE users SET is_deleted = true WHERE id = ?")
-@Table(name = "users")
+@Table(
+        name = "users",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_users_social_id_provider",
+                        columnNames = {"social_id", "provider"}
+                )
+        }
+)
 public class User {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id", nullable = false, updatable = false, unique = true)
     private Long id;
 
-    @Column(name = "social_id", unique = true)
+    @Column(name = "social_id")
     private String socialId;
 
     @Column(name = "provider", nullable = false)

--- a/src/main/java/com/gemmap/gemmap/auth/infrastructure/oauth/AppleOAuth2Service.java
+++ b/src/main/java/com/gemmap/gemmap/auth/infrastructure/oauth/AppleOAuth2Service.java
@@ -1,0 +1,180 @@
+package com.gemmap.gemmap.auth.infrastructure.oauth;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gemmap.gemmap.auth.application.dto.apple.AppleIdentityTokenClaims;
+import com.gemmap.gemmap.shared.exception.CommonException;
+import com.gemmap.gemmap.shared.exception.ErrorCode;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyFactory;
+import java.security.PublicKey;
+import java.security.spec.RSAPublicKeySpec;
+import java.util.Base64;
+import java.util.Collection;
+
+/**
+ * Apple OAuth2 서비스
+ * Apple Identity Token 검증 및 Apple 공개키 조회
+ */
+@Slf4j
+@Service
+public class AppleOAuth2Service {
+
+    private static final String APPLE_JWKS_URL = "https://appleid.apple.com/auth/keys";
+    private static final String APPLE_ISSUER = "https://appleid.apple.com";
+
+    private final ObjectMapper objectMapper;
+    private final RestTemplate restTemplate;
+
+    @Value("${oauth2.apple.bundle-id}")
+    private String bundleId;
+
+    public AppleOAuth2Service(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+
+        SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
+        requestFactory.setConnectTimeout(2000);
+        requestFactory.setReadTimeout(3000);
+        this.restTemplate = new RestTemplate(requestFactory);
+    }
+
+    public AppleIdentityTokenClaims validateAndExtractClaims(String identityToken) {
+        try {
+            String kid = extractKidFromToken(identityToken);
+            PublicKey publicKey = fetchPublicKey(kid);
+
+            Claims claims = Jwts.parser()
+                    .verifyWith(publicKey)
+                    .build()
+                    .parseSignedClaims(identityToken)
+                    .getPayload();
+
+            validateClaims(claims);
+
+            return new AppleIdentityTokenClaims(
+                    claims.getSubject(),
+                    claims.get("email", String.class)
+            );
+        } catch (CommonException e) {
+            throw e;
+        } catch (JwtException e) {
+            log.error("Apple Identity Token JWT 검증 실패: {}", e.getMessage());
+            throw new CommonException(ErrorCode.INVALID_TOKEN);
+        } catch (Exception e) {
+            log.error("Apple Identity Token 처리 중 오류: {}", e.getMessage(), e);
+            throw new CommonException(ErrorCode.INVALID_TOKEN);
+        }
+    }
+
+    private String extractKidFromToken(String identityToken) {
+        try {
+            String[] parts = identityToken.split("\\.");
+            if (parts.length != 3) {
+                throw new CommonException(ErrorCode.INVALID_TOKEN);
+            }
+
+            String decodedHeader = new String(Base64.getUrlDecoder().decode(parts[0]), StandardCharsets.UTF_8);
+            JsonNode headerNode = objectMapper.readTree(decodedHeader);
+            String kid = headerNode.path("kid").asText(null);
+
+            if (kid == null || kid.isEmpty()) {
+                log.error("Apple Identity Token 헤더에 kid 없음");
+                throw new CommonException(ErrorCode.INVALID_TOKEN);
+            }
+
+            return kid;
+        } catch (CommonException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("Apple Identity Token 헤더 파싱 실패: {}", e.getMessage());
+            throw new CommonException(ErrorCode.INVALID_TOKEN);
+        }
+    }
+
+    private PublicKey fetchPublicKey(String kid) {
+        try {
+            ResponseEntity<String> response = restTemplate.getForEntity(APPLE_JWKS_URL, String.class);
+            if (response.getStatusCode() != HttpStatus.OK || response.getBody() == null) {
+                log.error("Apple JWKS 조회 실패: {}", response.getStatusCode());
+                throw new CommonException(ErrorCode.OAUTH2_COMMUNICATION_ERROR);
+            }
+
+            JsonNode jwks = objectMapper.readTree(response.getBody());
+            JsonNode keys = jwks.get("keys");
+            if (keys == null || !keys.isArray()) {
+                throw new CommonException(ErrorCode.OAUTH2_COMMUNICATION_ERROR);
+            }
+
+            for (JsonNode key : keys) {
+                if (kid.equals(key.path("kid").asText())) {
+                    return convertJwkToPublicKey(key);
+                }
+            }
+
+            log.error("Apple JWKS에서 kid {} 를 찾을 수 없음", kid);
+            throw new CommonException(ErrorCode.INVALID_TOKEN);
+        } catch (CommonException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("Apple 공개키 조회 중 오류: {}", e.getMessage(), e);
+            throw new CommonException(ErrorCode.OAUTH2_COMMUNICATION_ERROR);
+        }
+    }
+
+    private PublicKey convertJwkToPublicKey(JsonNode jwk) {
+        try {
+            byte[] nBytes = Base64.getUrlDecoder().decode(jwk.get("n").asText());
+            byte[] eBytes = Base64.getUrlDecoder().decode(jwk.get("e").asText());
+
+            BigInteger n = new BigInteger(1, nBytes);
+            BigInteger e = new BigInteger(1, eBytes);
+
+            RSAPublicKeySpec spec = new RSAPublicKeySpec(n, e);
+            KeyFactory keyFactory = KeyFactory.getInstance("RSA");
+            return keyFactory.generatePublic(spec);
+        } catch (Exception e) {
+            log.error("JWK → RSA PublicKey 변환 실패: {}", e.getMessage(), e);
+            throw new CommonException(ErrorCode.OAUTH2_COMMUNICATION_ERROR);
+        }
+    }
+
+    private void validateClaims(Claims claims) {
+        if (!APPLE_ISSUER.equals(claims.getIssuer())) {
+            log.error("Apple Identity Token iss 불일치 - 예상: {}, 실제: {}", APPLE_ISSUER, claims.getIssuer());
+            throw new CommonException(ErrorCode.INVALID_TOKEN);
+        }
+
+        Object audienceClaim = claims.get("aud");
+        if (!matchesAudience(audienceClaim)) {
+            log.error("Apple Identity Token aud 불일치 - 예상: {}, 실제: {}", bundleId, audienceClaim);
+            throw new CommonException(ErrorCode.INVALID_TOKEN);
+        }
+    }
+
+    private boolean matchesAudience(Object audienceClaim) {
+        if (audienceClaim instanceof String aud) {
+            return bundleId.equals(aud);
+        }
+
+        if (audienceClaim instanceof Collection<?> audCollection) {
+            return audCollection.stream()
+                    .filter(String.class::isInstance)
+                    .map(String.class::cast)
+                    .anyMatch(bundleId::equals);
+        }
+
+        return false;
+    }
+}

--- a/src/main/java/com/gemmap/gemmap/auth/presentation/AuthController.java
+++ b/src/main/java/com/gemmap/gemmap/auth/presentation/AuthController.java
@@ -1,8 +1,9 @@
 package com.gemmap.gemmap.auth.presentation;
 
-import com.gemmap.gemmap.auth.application.dto.response.KakaoLoginResponseDto;
+import com.gemmap.gemmap.auth.application.dto.request.AppleLoginRequestDto;
 import com.gemmap.gemmap.auth.application.dto.response.PhotoConsentResponse;
 import com.gemmap.gemmap.auth.application.dto.response.RegisterResponseDto;
+import com.gemmap.gemmap.auth.application.dto.response.SocialLoginResponseDto;
 import com.gemmap.gemmap.auth.application.service.AuthService;
 import com.gemmap.gemmap.shared.common.annotation.UserId;
 import com.gemmap.gemmap.shared.common.constants.Constant;
@@ -32,15 +33,35 @@ public class AuthController {
      * 모바일 앱에서 획득한 카카오 Access Token으로 인증
      */
     @PostMapping("/kakao/login")
-    public ResponseEntity<KakaoLoginResponseDto> kakaoSdkLogin(HttpServletRequest request) {
+    public ResponseEntity<SocialLoginResponseDto> kakaoSdkLogin(HttpServletRequest request) {
         log.info("카카오 SDK 로그인 요청");
 
         // Authorization 헤더에서 카카오 Access Token 추출
         String kakaoAccessToken = HeaderUtil.refineHeader(request, Constant.AUTHORIZATION_HEADER, Constant.BEARER_PREFIX)
                 .orElseThrow(() -> new CommonException(ErrorCode.INVALID_TOKEN));
 
-        KakaoLoginResponseDto loginResponse = authService.authenticateWithKakaoAccessToken(kakaoAccessToken);
+        SocialLoginResponseDto loginResponse = authService.authenticateWithKakaoAccessToken(kakaoAccessToken);
         log.info("카카오 SDK 로그인 성공 - 사용자 ID: {}", loginResponse.userId());
+        return ResponseEntity.ok(loginResponse);
+    }
+
+    /**
+     * Apple 로그인 (모바일 SDK 방식)
+     * 모바일 앱에서 획득한 Apple Identity Token으로 인증
+     */
+    @PostMapping("/apple/login")
+    public ResponseEntity<SocialLoginResponseDto> appleLogin(
+            HttpServletRequest request,
+            @RequestBody(required = false) AppleLoginRequestDto loginRequest) {
+        log.info("Apple 로그인 요청");
+
+        String identityToken = HeaderUtil.refineHeader(request, Constant.AUTHORIZATION_HEADER, Constant.BEARER_PREFIX)
+                .orElseThrow(() -> new CommonException(ErrorCode.INVALID_TOKEN));
+
+        String name = loginRequest != null ? loginRequest.name() : null;
+
+        SocialLoginResponseDto loginResponse = authService.authenticateWithAppleToken(identityToken, name);
+        log.info("Apple 로그인 성공 - 사용자 ID: {}", loginResponse.userId());
         return ResponseEntity.ok(loginResponse);
     }
 
@@ -65,14 +86,14 @@ public class AuthController {
      * 서비스 JWT 액세스 토큰 갱신
      */
     @PostMapping("/refresh")
-    public ResponseEntity<KakaoLoginResponseDto> refreshToken(HttpServletRequest request) {
+    public ResponseEntity<SocialLoginResponseDto> refreshToken(HttpServletRequest request) {
         log.info("서비스 토큰 갱신 요청");
 
         // Authorization 헤더에서 서비스 Refresh Token 추출
         String refreshToken = HeaderUtil.refineHeader(request, Constant.AUTHORIZATION_HEADER, Constant.BEARER_PREFIX)
                 .orElseThrow(() -> new CommonException(ErrorCode.INVALID_TOKEN));
 
-        KakaoLoginResponseDto loginResponse = authService.refreshAccessToken(refreshToken);
+        SocialLoginResponseDto loginResponse = authService.refreshAccessToken(refreshToken);
         return ResponseEntity.ok(loginResponse);
     }
 

--- a/src/main/java/com/gemmap/gemmap/shared/common/constants/Constant.java
+++ b/src/main/java/com/gemmap/gemmap/shared/common/constants/Constant.java
@@ -24,6 +24,7 @@ public class Constant {
             "/api/v1/auth/login/kakao",
             "/api/v1/auth/kakao/callback",
             "/api/v1/auth/kakao/login",
+            "/api/v1/auth/apple/login",
 //            "/api/v1/auth/register",
             "/api/v1/test",
             "/swagger-ui.html",

--- a/src/main/java/com/gemmap/gemmap/shared/common/enums/EProvider.java
+++ b/src/main/java/com/gemmap/gemmap/shared/common/enums/EProvider.java
@@ -9,5 +9,6 @@ package com.gemmap.gemmap.shared.common.enums;
  * - 향후 추가 소셜 로그인 제공자 확장 가능
  */
 public enum EProvider {
-    KAKAO    // 카카오 소셜 로그인
+    KAKAO,   // 카카오 소셜 로그인
+    APPLE    // 애플 소셜 로그인
 }

--- a/src/main/java/com/gemmap/gemmap/shared/exception/ErrorCode.java
+++ b/src/main/java/com/gemmap/gemmap/shared/exception/ErrorCode.java
@@ -72,6 +72,7 @@ public enum ErrorCode {
     INVALID_FILE_FORMAT(40010, HttpStatus.BAD_REQUEST, "지원하지 않는 파일 형식입니다."),
     FILE_SIZE_EXCEEDED(40011, HttpStatus.BAD_REQUEST, "파일 크기가 너무 큽니다."),
     REPORT_CONTENT_REQUIRED(40012, HttpStatus.BAD_REQUEST, "'기타' 사유 선택 시 신고 내용을 입력해야 합니다."),
+    APPLE_REQUIRED_USER_INFO_MISSING(40013, HttpStatus.BAD_REQUEST, "Apple 최초 로그인에 필요한 사용자 정보가 누락되었습니다."),
 
     // OAuth2 관련 에러 (502 Bad Gateway - 외부 서비스 오류)
     KAKAO_TOKEN_REQUEST_FAILED(50201, HttpStatus.BAD_GATEWAY, "카카오 토큰 요청에 실패했습니다."),

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -31,6 +31,8 @@ oauth2:
     client-secret: "test-kakao-client-secret"
     redirect-uri: "http://localhost:8080/api/v1/auth/kakao/callback"
     app-id: 1234567890
+  apple:
+    bundle-id: ${APPLE_BUNDLE_ID}
 
 # S3 설정 (테스트용 - OCI S3 호환 모드)
 s3:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -38,6 +38,8 @@ oauth2:
     client-secret: ${KAKAO_CLIENT_SECRET}
     redirect-uri: ${KAKAO_REDIRECT_URI}
     app-id: ${KAKAO_APP_ID}
+  apple:
+    bundle-id: ${APPLE_BUNDLE_ID}
 
 # OCI Object Storage 설정 (S3 호환)
 s3:


### PR DESCRIPTION
## 요약
Apple Identity Token 기반 소셜 로그인 API를 구현함

<br>

## 작업 내용
- `POST /api/v1/auth/apple/login` 엔드포인트 추가
- Apple JWKS 공개키 기반 Identity Token 검증 (iss, aud, exp)
- 외부 검증과 DB 트랜잭션 분리 (`AppleLoginTransactionService`)
- `KakaoLoginResponseDto` → `SocialLoginResponseDto` rename
- `User` 엔티티 unique 제약을 `(social_id, provider)` 복합 unique로 변경

<br>

## 참고 사항
- Apple은 최초 로그인 시에만 name/email을 전달함 → 이후 요청에서는 Body 없이도 동작
- 동시 가입 충돌 방지: `DataIntegrityViolationException` catch 후 재조회 처리 포함

<br>

## 관련 이슈
- Refs #70 

<br>