### PR TITLE
Fix(auth): Apple 로그인 email을 Request Body로 전달받도록 수정

### DIFF
--- a/src/main/java/com/gemmap/gemmap/auth/application/dto/apple/AppleIdentityTokenClaims.java
+++ b/src/main/java/com/gemmap/gemmap/auth/application/dto/apple/AppleIdentityTokenClaims.java
@@ -4,7 +4,6 @@ package com.gemmap.gemmap.auth.application.dto.apple;
  * Apple Identity Token에서 파싱된 클레임 정보
  */
 public record AppleIdentityTokenClaims(
-        String sub,
-        String email
+        String sub
 ) {
 }

--- a/src/main/java/com/gemmap/gemmap/auth/application/dto/request/AppleLoginRequestDto.java
+++ b/src/main/java/com/gemmap/gemmap/auth/application/dto/request/AppleLoginRequestDto.java
@@ -2,9 +2,10 @@ package com.gemmap.gemmap.auth.application.dto.request;
 
 /**
  * Apple 로그인 요청 Body DTO
- * name은 최초 로그인 시 클라이언트가 전달해야 한다.
+ * name과 email은 최초 로그인 시 클라이언트가 전달해야 한다.
  */
 public record AppleLoginRequestDto(
-        String name
+        String name,
+        String email
 ) {
 }

--- a/src/main/java/com/gemmap/gemmap/auth/application/service/AuthService.java
+++ b/src/main/java/com/gemmap/gemmap/auth/application/service/AuthService.java
@@ -111,24 +111,17 @@ public class AuthService {
      * 외부 Apple 토큰 검증은 트랜잭션 밖에서 수행하고,
      * DB 작업은 AppleLoginTransactionService로 위임한다.
      */
-    public SocialLoginResponseDto authenticateWithAppleToken(String identityToken, String name) {
+    public SocialLoginResponseDto authenticateWithAppleToken(String identityToken, String email, String name) {
         if (identityToken == null || identityToken.trim().isEmpty()) {
             throw new CommonException(ErrorCode.INVALID_INPUT_VALUE);
         }
 
-        try {
-            AppleIdentityTokenClaims claims = appleOAuth2Service.validateAndExtractClaims(identityToken);
-            return appleLoginTransactionService.completeAppleLogin(
-                    claims.sub(),
-                    claims.email(),
-                    name
-            );
-        } catch (CommonException e) {
-            throw e;
-        } catch (Exception e) {
-            log.error("Apple 로그인 처리 중 예상치 못한 오류: {}", e.getMessage(), e);
-            throw new CommonException(ErrorCode.INTERNAL_SERVER_ERROR);
-        }
+        AppleIdentityTokenClaims claims = appleOAuth2Service.validateAndExtractClaims(identityToken);
+        return appleLoginTransactionService.completeAppleLogin(
+                claims.sub(),
+                email,
+                name
+        );
     }
 
     /**

--- a/src/main/java/com/gemmap/gemmap/auth/infrastructure/oauth/AppleOAuth2Service.java
+++ b/src/main/java/com/gemmap/gemmap/auth/infrastructure/oauth/AppleOAuth2Service.java
@@ -64,8 +64,7 @@ public class AppleOAuth2Service {
             validateClaims(claims);
 
             return new AppleIdentityTokenClaims(
-                    claims.getSubject(),
-                    claims.get("email", String.class)
+                    claims.getSubject()
             );
         } catch (CommonException e) {
             throw e;

--- a/src/main/java/com/gemmap/gemmap/auth/presentation/AuthController.java
+++ b/src/main/java/com/gemmap/gemmap/auth/presentation/AuthController.java
@@ -59,8 +59,9 @@ public class AuthController {
                 .orElseThrow(() -> new CommonException(ErrorCode.INVALID_TOKEN));
 
         String name = loginRequest != null ? loginRequest.name() : null;
+        String email = loginRequest != null ? loginRequest.email() : null;
 
-        SocialLoginResponseDto loginResponse = authService.authenticateWithAppleToken(identityToken, name);
+        SocialLoginResponseDto loginResponse = authService.authenticateWithAppleToken(identityToken, email, name);
         log.info("Apple 로그인 성공 - 사용자 ID: {}", loginResponse.userId());
         return ResponseEntity.ok(loginResponse);
     }


### PR DESCRIPTION
## 요약
Apple Identity Token에 `email` 클레임이 포함되지 않아 신규 사용자 로그인 시 401 에러가 발생하는 버그를 수정.
`name`과 동일하게 `email`도 Request Body로 전달받도록 변경.


<br>

## 작업 내용
- `AppleLoginRequestDto`에 `email` 필드 추가
- `AppleIdentityTokenClaims`에서 `email` 필드 제거 (토큰에 미포함)
- `AppleOAuth2Service.validateAndExtractClaims()`에서 email 클레임 추출 로직 제거
- `AuthService.authenticateWithAppleToken()`에 `email` 파라미터 추가
- `AuthService` 불필요한 try-catch 제거 (호출 메서드들이 이미 내부에서 모두 CommonException으로 변환)

<br>

## 참고 사항
- 엔드포인트 URL 및 인증 방식 변경 없음
- Apple 이메일 숨기기(`privaterelay.appleid.com`) 허용 — 별도 형식 검증 없음

<br>

## 관련 이슈
- Refs #72 

<br>