### PR TITLE
Feat(auth): 소셜 로그인 회원 탈퇴(연결 해제) API 구현

### DIFF
--- a/.github/workflows/develop-cd.yml
+++ b/.github/workflows/develop-cd.yml
@@ -97,7 +97,13 @@ jobs:
               -e KAKAO_CLIENT_SECRET='${{ secrets.KAKAO_CLIENT_SECRET }}' \
               -e KAKAO_REDIRECT_URI='${{ secrets.KAKAO_REDIRECT_URI }}' \
               -e KAKAO_APP_ID='${{ secrets.KAKAO_APP_ID }}' \
+              -e KAKAO_ADMIN_KEY='${{ secrets.KAKAO_ADMIN_KEY }}' \
               -e APPLE_BUNDLE_ID='${{ secrets.APPLE_BUNDLE_ID }}' \
+              -e APPLE_TEAM_ID='${{ secrets.APPLE_TEAM_ID }}' \
+              -e APPLE_KEY_ID='${{ secrets.APPLE_KEY_ID }}' \
+              -e APPLE_PRIVATE_KEY='${{ secrets.APPLE_PRIVATE_KEY }}' \
+              -e APPLE_REFRESH_TOKEN_ENC_PASSWORD='${{ secrets.APPLE_REFRESH_TOKEN_ENC_PASSWORD }}' \
+              -e APPLE_REFRESH_TOKEN_ENC_SALT='${{ secrets.APPLE_REFRESH_TOKEN_ENC_SALT }}' \
               \
               -e S3_ENDPOINT='${{ secrets.S3_ENDPOINT }}' \
               -e S3_REGION='${{ secrets.S3_REGION }}' \

--- a/src/main/java/com/gemmap/gemmap/auth/application/dto/apple/AppleTokenResponse.java
+++ b/src/main/java/com/gemmap/gemmap/auth/application/dto/apple/AppleTokenResponse.java
@@ -1,0 +1,16 @@
+package com.gemmap.gemmap.auth.application.dto.apple;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Apple /auth/token 응답 DTO (authorization_code 교환 결과).
+ *
+ * Apple은 access_token, token_type, expires_in, refresh_token, id_token을 응답하지만,
+ * 본 서비스에서 실제로 사용하는 값은 refresh_token 뿐이므로 나머지 필드는 역직렬화 시 무시한다.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record AppleTokenResponse(
+        @JsonProperty("refresh_token") String refreshToken
+) {
+}

--- a/src/main/java/com/gemmap/gemmap/auth/application/dto/request/AppleLoginRequestDto.java
+++ b/src/main/java/com/gemmap/gemmap/auth/application/dto/request/AppleLoginRequestDto.java
@@ -1,11 +1,16 @@
 package com.gemmap.gemmap.auth.application.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
+
 /**
- * Apple 로그인 요청 Body DTO
- * name과 email은 최초 로그인 시 클라이언트가 전달해야 한다.
+ * Apple 로그인 요청 Body DTO.
+ * - name, email: 최초 로그인 시 클라이언트가 전달
+ * - authorizationCode: Apple revoke 호출용 refresh_token 확보에 필수
  */
 public record AppleLoginRequestDto(
         String name,
-        String email
+        String email,
+        @NotBlank(message = "authorizationCode는 필수입니다.")
+        String authorizationCode
 ) {
 }

--- a/src/main/java/com/gemmap/gemmap/auth/application/service/AppleLoginTransactionService.java
+++ b/src/main/java/com/gemmap/gemmap/auth/application/service/AppleLoginTransactionService.java
@@ -24,8 +24,12 @@ public class AppleLoginTransactionService {
     private final JwtUtil jwtUtil;
 
     @Transactional
-    public SocialLoginResponseDto completeAppleLogin(String socialId, String email, String name) {
+    public SocialLoginResponseDto completeAppleLogin(
+            String socialId, String email, String name, String encryptedAppleRefreshToken
+    ) {
         User user = findOrCreateAppleUser(socialId, email, name);
+
+        user.updateAppleRefreshToken(encryptedAppleRefreshToken);
 
         JwtTokenDto jwtTokenDto = jwtUtil.generateTokens(user.getId(), user.getRole());
         user.updateRefreshToken(jwtTokenDto.getRefreshToken());

--- a/src/main/java/com/gemmap/gemmap/auth/application/service/AuthService.java
+++ b/src/main/java/com/gemmap/gemmap/auth/application/service/AuthService.java
@@ -1,6 +1,7 @@
 package com.gemmap.gemmap.auth.application.service;
 
 import com.gemmap.gemmap.auth.application.dto.apple.AppleIdentityTokenClaims;
+import com.gemmap.gemmap.auth.application.dto.apple.AppleTokenResponse;
 import com.gemmap.gemmap.auth.application.dto.kakao.KakaoAccessTokenInfoResponse;
 import com.gemmap.gemmap.auth.application.dto.kakao.KakaoUserInfoResponse;
 import com.gemmap.gemmap.auth.application.dto.response.PhotoConsentResponse;
@@ -22,6 +23,8 @@ import com.gemmap.gemmap.shared.infrastructure.objectstorage.ObjectStorageServic
 import com.gemmap.gemmap.shared.infrastructure.objectstorage.S3UrlGenerator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.security.crypto.encrypt.TextEncryptor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -53,6 +56,11 @@ public class AuthService {
     private final KakaoOAuth2Service kakaoOAuth2Service;
     private final AppleOAuth2Service appleOAuth2Service;
     private final AppleLoginTransactionService appleLoginTransactionService;
+    private final WithdrawTransactionService withdrawTransactionService;
+
+    @Qualifier("appleRefreshTokenEncryptor")
+    private final TextEncryptor appleRefreshTokenEncryptor;
+
     private final ObjectStorageService objectStorageService;
     private final S3UrlGenerator s3UrlGenerator;
     private final S3Properties s3Properties;
@@ -108,19 +116,31 @@ public class AuthService {
 
     /**
      * Apple Identity Token으로 인증 (모바일 SDK 방식)
-     * 외부 Apple 토큰 검증은 트랜잭션 밖에서 수행하고,
-     * DB 작업은 AppleLoginTransactionService로 위임한다.
+     * 외부 Apple 토큰 검증·authorization_code 교환·암호화는 트랜잭션 밖에서 수행하고,
+     * DB 작업만 AppleLoginTransactionService로 위임한다.
      */
-    public SocialLoginResponseDto authenticateWithAppleToken(String identityToken, String email, String name) {
+    public SocialLoginResponseDto authenticateWithAppleToken(
+            String identityToken, String email, String name, String authorizationCode
+    ) {
         if (identityToken == null || identityToken.trim().isEmpty()) {
             throw new CommonException(ErrorCode.INVALID_INPUT_VALUE);
         }
+        if (authorizationCode == null || authorizationCode.trim().isEmpty()) {
+            throw new CommonException(ErrorCode.INVALID_INPUT_VALUE);
+        }
 
+        // 1) identityToken 검증 — 외부 HTTP (JWKS)
         AppleIdentityTokenClaims claims = appleOAuth2Service.validateAndExtractClaims(identityToken);
+
+        // 2) authorizationCode 교환 — 외부 HTTP (/auth/token)
+        AppleTokenResponse tokenResponse = appleOAuth2Service.exchangeAuthorizationCode(authorizationCode);
+
+        // 3) refresh_token 암호화
+        String encryptedAppleRefreshToken = appleRefreshTokenEncryptor.encrypt(tokenResponse.refreshToken());
+
+        // 4) DB 반영은 @Transactional 서비스로 위임
         return appleLoginTransactionService.completeAppleLogin(
-                claims.sub(),
-                email,
-                name
+                claims.sub(), email, name, encryptedAppleRefreshToken
         );
     }
 
@@ -520,6 +540,42 @@ public class AuthService {
             log.error("로그아웃 처리 중 예상치 못한 오류: {}", e.getMessage(), e);
             throw new CommonException(ErrorCode.INTERNAL_SERVER_ERROR);
         }
+    }
+
+    /**
+     * 회원 탈퇴
+     * - Kakao: Admin Key로 unlink
+     * - Apple: 저장된 refresh_token을 복호화 후 revoke
+     * 외부 API는 트랜잭션 외부에서 수행, DB 반영은 WithdrawTransactionService.
+     */
+    public void withdraw(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CommonException(ErrorCode.USER_NOT_FOUND));
+
+        // 이미 탈퇴된 사용자 → 멱등 성공 처리
+        if (Boolean.TRUE.equals(user.getIsDeleted())) {
+            log.info("이미 탈퇴된 사용자의 탈퇴 재요청 - 멱등 성공 처리: userId={}", userId);
+            return;
+        }
+
+        switch (user.getEProvider()) {
+            case KAKAO -> {
+                long kakaoUserId = Long.parseLong(user.getSocialId());
+                kakaoOAuth2Service.unlink(kakaoUserId);
+            }
+            case APPLE -> {
+                String encrypted = user.getAppleRefreshToken();
+                if (encrypted == null || encrypted.isBlank()) {
+                    log.error("Apple 탈퇴 — apple_refresh_token 부재(설계상 발생 불가): userId={}", userId);
+                    throw new CommonException(ErrorCode.INTERNAL_SERVER_ERROR);
+                }
+                String refreshToken = appleRefreshTokenEncryptor.decrypt(encrypted);
+                appleOAuth2Service.revokeRefreshToken(refreshToken);
+            }
+        }
+
+        withdrawTransactionService.finalizeWithdraw(userId);
+        log.info("회원 탈퇴 완료 - userId: {}, provider: {}", userId, user.getEProvider());
     }
 
     /**

--- a/src/main/java/com/gemmap/gemmap/auth/application/service/WithdrawTransactionService.java
+++ b/src/main/java/com/gemmap/gemmap/auth/application/service/WithdrawTransactionService.java
@@ -1,0 +1,33 @@
+package com.gemmap.gemmap.auth.application.service;
+
+import com.gemmap.gemmap.auth.domain.entity.User;
+import com.gemmap.gemmap.auth.domain.repository.UserRepository;
+import com.gemmap.gemmap.shared.exception.CommonException;
+import com.gemmap.gemmap.shared.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 탈퇴 마무리 DB 업데이트 전담 서비스.
+ * 외부 API 호출은 AuthService에서 트랜잭션 밖에서 수행 후 이 메서드 호출.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class WithdrawTransactionService {
+
+    private final UserRepository userRepository;
+
+    @Transactional
+    public void finalizeWithdraw(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CommonException(ErrorCode.USER_NOT_FOUND));
+
+        user.clearAppleRefreshToken();
+        user.withdrawUser();
+
+        log.info("회원 탈퇴 DB 반영 완료 - userId: {}", userId);
+    }
+}

--- a/src/main/java/com/gemmap/gemmap/auth/domain/entity/User.java
+++ b/src/main/java/com/gemmap/gemmap/auth/domain/entity/User.java
@@ -75,6 +75,9 @@ public class User {
     @Column(name = "photo_consent_agreed_at")
     private LocalDateTime photoConsentAgreedAt;
 
+    @Column(name = "apple_refresh_token", length = 500)
+    private String appleRefreshToken;
+
     /* User Info */
 
     @Column(name = "email")
@@ -173,6 +176,14 @@ public class User {
         this.deleteDate = LocalDate.now(KST);
         this.refreshToken = null;
         this.isLogin = false;
+    }
+
+    public void updateAppleRefreshToken(String encryptedRefreshToken) {
+        this.appleRefreshToken = encryptedRefreshToken;
+    }
+
+    public void clearAppleRefreshToken() {
+        this.appleRefreshToken = null;
     }
 
     public void recoverUser() {

--- a/src/main/java/com/gemmap/gemmap/auth/infrastructure/oauth/AppleOAuth2Service.java
+++ b/src/main/java/com/gemmap/gemmap/auth/infrastructure/oauth/AppleOAuth2Service.java
@@ -3,6 +3,7 @@ package com.gemmap.gemmap.auth.infrastructure.oauth;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.gemmap.gemmap.auth.application.dto.apple.AppleIdentityTokenClaims;
+import com.gemmap.gemmap.auth.application.dto.apple.AppleTokenResponse;
 import com.gemmap.gemmap.shared.exception.CommonException;
 import com.gemmap.gemmap.shared.exception.ErrorCode;
 import io.jsonwebtoken.Claims;
@@ -10,23 +11,30 @@ import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.*;
 import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.security.KeyFactory;
 import java.security.PublicKey;
+import java.security.interfaces.ECPrivateKey;
+import java.security.spec.PKCS8EncodedKeySpec;
 import java.security.spec.RSAPublicKeySpec;
+import java.time.Instant;
 import java.util.Base64;
 import java.util.Collection;
+import java.util.Date;
 
 /**
  * Apple OAuth2 서비스
- * Apple Identity Token 검증 및 Apple 공개키 조회
+ * Apple Identity Token 검증, Authorization Code 교환, Token Revocation
  */
 @Slf4j
 @Service
@@ -34,12 +42,27 @@ public class AppleOAuth2Service {
 
     private static final String APPLE_JWKS_URL = "https://appleid.apple.com/auth/keys";
     private static final String APPLE_ISSUER = "https://appleid.apple.com";
+    private static final String APPLE_TOKEN_URL = "https://appleid.apple.com/auth/token";
+    private static final String APPLE_REVOKE_URL = "https://appleid.apple.com/auth/revoke";
+    private static final long CLIENT_SECRET_TTL_SECONDS = 300L; // 5분
+    private static final String APPLE_REQUEST_USER_AGENT = "gemmap-backend";
 
     private final ObjectMapper objectMapper;
     private final RestTemplate restTemplate;
 
     @Value("${oauth2.apple.bundle-id}")
     private String bundleId;
+
+    @Value("${oauth2.apple.team-id}")
+    private String teamId;
+
+    @Value("${oauth2.apple.key-id}")
+    private String keyId;
+
+    @Value("${oauth2.apple.private-key}")
+    private String privateKeyPem;
+
+    private ECPrivateKey cachedPrivateKey; // PEM 파싱 결과만 캐시 (JWT 자체는 매 요청 생성)
 
     public AppleOAuth2Service(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
@@ -49,6 +72,8 @@ public class AppleOAuth2Service {
         requestFactory.setReadTimeout(3000);
         this.restTemplate = new RestTemplate(requestFactory);
     }
+
+    // ========== Identity Token 검증 (기존) ==========
 
     public AppleIdentityTokenClaims validateAndExtractClaims(String identityToken) {
         try {
@@ -76,6 +101,154 @@ public class AppleOAuth2Service {
             throw new CommonException(ErrorCode.INVALID_TOKEN);
         }
     }
+
+    // ========== Authorization Code 교환 (신규) ==========
+
+    /**
+     * Apple authorization_code 교환 → refresh_token 확보
+     */
+    public AppleTokenResponse exchangeAuthorizationCode(String authorizationCode) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        headers.set(HttpHeaders.USER_AGENT, APPLE_REQUEST_USER_AGENT);
+
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("client_id", bundleId);
+        params.add("client_secret", generateClientSecret());
+        params.add("code", authorizationCode);
+        params.add("grant_type", "authorization_code");
+
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(params, headers);
+
+        try {
+            ResponseEntity<AppleTokenResponse> response = restTemplate.exchange(
+                    APPLE_TOKEN_URL,
+                    HttpMethod.POST,
+                    request,
+                    AppleTokenResponse.class
+            );
+
+            if (response.getStatusCode() == HttpStatus.OK
+                    && response.getBody() != null
+                    && response.getBody().refreshToken() != null) {
+                return response.getBody();
+            }
+
+            log.error("Apple token exchange 비정상 응답: status={}", response.getStatusCode());
+            throw new CommonException(ErrorCode.OAUTH2_COMMUNICATION_ERROR);
+        } catch (HttpClientErrorException.BadRequest e) {
+            // authorization code 재사용/만료(invalid_grant) 등 클라이언트 요인 400 에러
+            log.warn("Apple token exchange 400: body={}", e.getResponseBodyAsString());
+            throw new CommonException(ErrorCode.INVALID_INPUT_VALUE);
+        } catch (CommonException e) {
+            throw e;
+        } catch (RestClientException e) {
+            log.error("Apple token exchange RestClient 오류: {}", e.getMessage(), e);
+            throw new CommonException(ErrorCode.OAUTH2_COMMUNICATION_ERROR);
+        }
+    }
+
+    // ========== Token Revocation (신규) ==========
+
+    /**
+     * Apple refresh_token revoke.
+     * 성공(200) 또는 invalid_grant(400) → 멱등 성공 처리.
+     */
+    public void revokeRefreshToken(String refreshToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        headers.set(HttpHeaders.USER_AGENT, APPLE_REQUEST_USER_AGENT);
+
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("client_id", bundleId);
+        params.add("client_secret", generateClientSecret());
+        params.add("token", refreshToken);
+        params.add("token_type_hint", "refresh_token");
+
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(params, headers);
+
+        try {
+            ResponseEntity<String> response = restTemplate.exchange(
+                    APPLE_REVOKE_URL,
+                    HttpMethod.POST,
+                    request,
+                    String.class
+            );
+
+            if (response.getStatusCode() == HttpStatus.OK) {
+                log.info("Apple token revoke 성공");
+                return;
+            }
+
+            log.error("Apple revoke 비정상 응답: status={}, body={}", response.getStatusCode(), response.getBody());
+            throw new CommonException(ErrorCode.OAUTH2_COMMUNICATION_ERROR);
+        } catch (HttpClientErrorException.BadRequest e) {
+            // invalid_grant: 이미 무효화된 토큰 → 멱등 성공
+            String body = e.getResponseBodyAsString();
+            if (body != null && body.contains("invalid_grant")) {
+                log.info("Apple revoke: 이미 무효화된 토큰 (invalid_grant) - 멱등 성공 처리");
+                return;
+            }
+            log.error("Apple revoke 400: body={}", body);
+            throw new CommonException(ErrorCode.OAUTH2_COMMUNICATION_ERROR);
+        } catch (CommonException e) {
+            throw e;
+        } catch (RestClientException e) {
+            log.error("Apple revoke RestClient 오류: {}", e.getMessage(), e);
+            throw new CommonException(ErrorCode.OAUTH2_COMMUNICATION_ERROR);
+        }
+    }
+
+    // ========== client_secret JWT 생성 (Apple 공식 권장: 매 요청 생성) ==========
+
+    private String generateClientSecret() {
+        try {
+            ECPrivateKey privateKey = loadPrivateKey();
+            Instant now = Instant.now();
+
+            return Jwts.builder()
+                    .header()
+                        .keyId(keyId)
+                        .and()
+                    .issuer(teamId)
+                    .issuedAt(Date.from(now))
+                    .expiration(Date.from(now.plusSeconds(CLIENT_SECRET_TTL_SECONDS)))
+                    .audience().add(APPLE_ISSUER).and()
+                    .subject(bundleId)
+                    .signWith(privateKey, Jwts.SIG.ES256)
+                    .compact();
+        } catch (CommonException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("Apple client_secret 생성 실패: {}", e.getMessage(), e);
+            throw new CommonException(ErrorCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    /**
+     * .p8 PEM → ECPrivateKey (BouncyCastle 없이 JCA 표준)
+     */
+    private synchronized ECPrivateKey loadPrivateKey() {
+        if (cachedPrivateKey != null) {
+            return cachedPrivateKey;
+        }
+        try {
+            String pem = privateKeyPem
+                    .replace("-----BEGIN PRIVATE KEY-----", "")
+                    .replace("-----END PRIVATE KEY-----", "")
+                    .replaceAll("\\s", "");
+            byte[] decoded = Base64.getDecoder().decode(pem);
+            PKCS8EncodedKeySpec spec = new PKCS8EncodedKeySpec(decoded);
+            KeyFactory keyFactory = KeyFactory.getInstance("EC");
+            cachedPrivateKey = (ECPrivateKey) keyFactory.generatePrivate(spec);
+            return cachedPrivateKey;
+        } catch (Exception e) {
+            log.error("Apple .p8 Private Key 로딩 실패: {}", e.getMessage(), e);
+            throw new CommonException(ErrorCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    // ========== Identity Token 내부 메서드 (기존 유지) ==========
 
     private String extractKidFromToken(String identityToken) {
         try {

--- a/src/main/java/com/gemmap/gemmap/auth/infrastructure/oauth/KakaoOAuth2Service.java
+++ b/src/main/java/com/gemmap/gemmap/auth/infrastructure/oauth/KakaoOAuth2Service.java
@@ -12,6 +12,8 @@ import org.springframework.http.*;
 import org.springframework.stereotype.Service;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
@@ -37,12 +39,16 @@ public class KakaoOAuth2Service {
     @Value("${oauth2.kakao.app-id}")
     private Long appId;
 
+    @Value("${oauth2.kakao.admin-key}")
+    private String adminKey;
+
     private static final String KAUTH_HOST = "https://kauth.kakao.com";
     private static final String KAPI_HOST = "https://kapi.kakao.com";
     private static final String TOKEN_ENDPOINT = "/oauth/token";
     private static final String USER_INFO_ENDPOINT = "/v2/user/me";
     private static final String ACCESS_TOKEN_INFO_ENDPOINT = "/v1/user/access_token_info";
     private static final String LOGOUT_ENDPOINT = "/v1/user/logout";
+    private static final String UNLINK_ENDPOINT = "/v1/user/unlink";
     private static final String AUTHORIZE_ENDPOINT = "/oauth/authorize";
     private static final String DEFAULT_SCOPE = "profile_nickname profile_image account_email name gender age_range birthday birthyear";
     private static final String PROPERTY_KEYS = "[\"kakao_account.profile\", \"kakao_account.email\", \"kakao_account.name\", \"kakao_account.gender\", \"kakao_account.age_range\", \"kakao_account.birthday\", \"kakao_account.birthyear\"]";
@@ -256,6 +262,50 @@ public class KakaoOAuth2Service {
         } catch (Exception e) {
             log.warn("카카오 로그아웃 API 호출 실패 (계속 진행): {}", e.getMessage());
             // 카카오 로그아웃 실패는 서비스 로그아웃에 영향을 주지 않음
+        }
+    }
+
+    /**
+     * Kakao 연결 끊기 (Admin Key 방식)
+     *
+     * 성공: 200 { "id": socialId } / 404(이미 해제됨): 멱등 성공 처리
+     * 그 외 실패: CommonException(KAKAO_UNLINK_FAILED)
+     */
+    public void unlink(long socialId) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        headers.set(HttpHeaders.AUTHORIZATION, "KakaoAK " + adminKey);
+
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("target_id_type", "user_id");
+        params.add("target_id", String.valueOf(socialId));
+
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(params, headers);
+
+        try {
+            ResponseEntity<String> response = restTemplate.exchange(
+                    KAPI_HOST + UNLINK_ENDPOINT,
+                    HttpMethod.POST,
+                    request,
+                    String.class
+            );
+
+            if (response.getStatusCode() == HttpStatus.OK) {
+                log.info("Kakao unlink 성공 - socialId: {}", socialId);
+                return;
+            }
+
+            log.error("Kakao unlink 비정상 응답: status={}, body={}", response.getStatusCode(), response.getBody());
+            throw new CommonException(ErrorCode.KAKAO_UNLINK_FAILED);
+        } catch (HttpClientErrorException.NotFound e) {
+            // 이미 해제된 사용자 → 멱등 처리
+            log.info("Kakao unlink: 이미 해제된 사용자 (404) - socialId: {}", socialId);
+        } catch (HttpClientErrorException e) {
+            log.error("Kakao unlink 4xx: status={}, body={}", e.getStatusCode(), e.getResponseBodyAsString());
+            throw new CommonException(ErrorCode.KAKAO_UNLINK_FAILED);
+        } catch (RestClientException e) {
+            log.error("Kakao unlink RestClient 오류: {}", e.getMessage(), e);
+            throw new CommonException(ErrorCode.KAKAO_UNLINK_FAILED);
         }
     }
 }

--- a/src/main/java/com/gemmap/gemmap/auth/presentation/AuthController.java
+++ b/src/main/java/com/gemmap/gemmap/auth/presentation/AuthController.java
@@ -11,6 +11,7 @@ import com.gemmap.gemmap.shared.exception.CommonException;
 import com.gemmap.gemmap.shared.exception.ErrorCode;
 import com.gemmap.gemmap.shared.util.HeaderUtil;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -52,16 +53,18 @@ public class AuthController {
     @PostMapping("/apple/login")
     public ResponseEntity<SocialLoginResponseDto> appleLogin(
             HttpServletRequest request,
-            @RequestBody(required = false) AppleLoginRequestDto loginRequest) {
+            @Valid @RequestBody AppleLoginRequestDto loginRequest) {
         log.info("Apple 로그인 요청");
 
         String identityToken = HeaderUtil.refineHeader(request, Constant.AUTHORIZATION_HEADER, Constant.BEARER_PREFIX)
                 .orElseThrow(() -> new CommonException(ErrorCode.INVALID_TOKEN));
 
-        String name = loginRequest != null ? loginRequest.name() : null;
-        String email = loginRequest != null ? loginRequest.email() : null;
-
-        SocialLoginResponseDto loginResponse = authService.authenticateWithAppleToken(identityToken, email, name);
+        SocialLoginResponseDto loginResponse = authService.authenticateWithAppleToken(
+                identityToken,
+                loginRequest.email(),
+                loginRequest.name(),
+                loginRequest.authorizationCode()
+        );
         log.info("Apple 로그인 성공 - 사용자 ID: {}", loginResponse.userId());
         return ResponseEntity.ok(loginResponse);
     }
@@ -107,6 +110,17 @@ public class AuthController {
         log.info("서비스 로그아웃 요청 - 사용자 ID: {}", userId);
 
         authService.logout(userId);
+        return ResponseEntity.noContent().build();
+    }
+
+    /**
+     * 회원 탈퇴
+     * - Provider(Kakao/Apple)별 연결 해제 수행 후 서비스 탈퇴 처리
+     */
+    @PostMapping("/withdraw")
+    public ResponseEntity<Void> withdraw(@UserId Long userId) {
+        log.info("회원 탈퇴 요청 - 사용자 ID: {}", userId);
+        authService.withdraw(userId);
         return ResponseEntity.noContent().build();
     }
 

--- a/src/main/java/com/gemmap/gemmap/shared/config/EncryptionConfig.java
+++ b/src/main/java/com/gemmap/gemmap/shared/config/EncryptionConfig.java
@@ -1,0 +1,23 @@
+package com.gemmap.gemmap.shared.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.encrypt.Encryptors;
+import org.springframework.security.crypto.encrypt.TextEncryptor;
+
+/**
+ * Apple refresh_token 전용 암복호화 Bean 설정.
+ * Spring Security Crypto의 Encryptors.text (AES-256-CBC + 랜덤 IV)를 재사용한다.
+ */
+@Configuration
+public class EncryptionConfig {
+
+    @Bean(name = "appleRefreshTokenEncryptor")
+    public TextEncryptor appleRefreshTokenEncryptor(
+            @Value("${crypto.apple-refresh-token.enc-password}") String password,
+            @Value("${crypto.apple-refresh-token.enc-salt}") String saltHex
+    ) {
+        return Encryptors.text(password, saltHex);
+    }
+}

--- a/src/main/java/com/gemmap/gemmap/shared/exception/ErrorCode.java
+++ b/src/main/java/com/gemmap/gemmap/shared/exception/ErrorCode.java
@@ -78,7 +78,8 @@ public enum ErrorCode {
     KAKAO_TOKEN_REQUEST_FAILED(50201, HttpStatus.BAD_GATEWAY, "카카오 토큰 요청에 실패했습니다."),
     KAKAO_USER_INFO_REQUEST_FAILED(50202, HttpStatus.BAD_GATEWAY, "카카오 사용자 정보 조회에 실패했습니다."),
     KAKAO_TOKEN_REFRESH_FAILED(50203, HttpStatus.BAD_GATEWAY, "카카오 토큰 갱신에 실패했습니다."),
-    OAUTH2_COMMUNICATION_ERROR(50204, HttpStatus.BAD_GATEWAY, "OAuth2 제공자와의 통신 중 오류가 발생했습니다.");
+    OAUTH2_COMMUNICATION_ERROR(50204, HttpStatus.BAD_GATEWAY, "OAuth2 제공자와의 통신 중 오류가 발생했습니다."),
+    KAKAO_UNLINK_FAILED(50205, HttpStatus.BAD_GATEWAY, "카카오 계정 연결 해제에 실패했습니다.");
 
     private final int code;
     private final HttpStatus httpStatus;

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -31,8 +31,18 @@ oauth2:
     client-secret: "test-kakao-client-secret"
     redirect-uri: "http://localhost:8080/api/v1/auth/kakao/callback"
     app-id: 1234567890
+    admin-key: "test-kakao-admin-key"
   apple:
-    bundle-id: ${APPLE_BUNDLE_ID}
+    bundle-id: "com.test.gemmap"
+    team-id: "TEST_TEAM"
+    key-id: "TEST_KEY_ID"
+    private-key: "test-private-key"
+
+# 암호화 설정 (테스트용)
+crypto:
+  apple-refresh-token:
+    enc-password: "test-enc-password"
+    enc-salt: "abcdef0123456789abcdef0123456789"
 
 # S3 설정 (테스트용 - OCI S3 호환 모드)
 s3:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -38,8 +38,18 @@ oauth2:
     client-secret: ${KAKAO_CLIENT_SECRET}
     redirect-uri: ${KAKAO_REDIRECT_URI}
     app-id: ${KAKAO_APP_ID}
+    admin-key: ${KAKAO_ADMIN_KEY}
   apple:
     bundle-id: ${APPLE_BUNDLE_ID}
+    team-id: ${APPLE_TEAM_ID}
+    key-id: ${APPLE_KEY_ID}
+    private-key: ${APPLE_PRIVATE_KEY}
+
+# 암호화 설정 — Spring Security Encryptors.text (AES-256-CBC + 랜덤 IV)
+crypto:
+  apple-refresh-token:
+    enc-password: ${APPLE_REFRESH_TOKEN_ENC_PASSWORD}
+    enc-salt: ${APPLE_REFRESH_TOKEN_ENC_SALT}
 
 # OCI Object Storage 설정 (S3 호환)
 s3:


### PR DESCRIPTION
## 요약
회원 탈퇴 시 Kakao/Apple Provider와의 연결을 해제하는 API를 구현함.  
Apple은 App Store 정책상 Token Revocation이 필수이며, Kakao는 Admin Key 기반 Unlink로 동의 철회를 수행함.

<br>

## 작업 내용
- `POST /api/v1/auth/withdraw` 신규 (JWT 필수, 204 응답)
  - Kakao: Admin Key 방식 `/v1/user/unlink`
  - Apple: 사전 저장된 `refresh_token`으로 `/auth/revoke`
- `POST /api/v1/auth/apple/login` Request Body에 `authorizationCode` **필수 필드 추가** — 서버가 `/auth/token`으로 교환해 `refresh_token` 암호화 저장
- `User.apple_refresh_token` 컬럼 추가 (Spring `Encryptors.text` 암호화)
- 신규 `ErrorCode.KAKAO_UNLINK_FAILED` 1건, 나머지는 기존 코드 재사용
- 외부 API 호출은 트랜잭션 외부, DB 반영은 `@Transactional` 분리 (탈퇴·로그인 모두 일관)
- 신규 환경변수 6종 + `develop-cd.yml` 매핑 추가

<br>

## 참고 사항
- iOS
  - Apple 로그인 시 `authorizationCode`를 Body에 함께 전달 (SDK가 `identityToken`과 동시 발급)
  - 테스트 계정은 iOS 설정 → "Apple로 로그인 중인 앱"에서 사전 연결 해제 필요
- 운영 전 필수 작업
  - GitHub Actions Secrets에 6개 신규 값 등록 (`KAKAO_ADMIN_KEY`, `APPLE_{TEAM_ID, KEY_ID, PRIVATE_KEY}`, `APPLE_REFRESH_TOKEN_ENC_{PASSWORD, SALT}`)
  - 배포 직전 테스트 DB의 기존 Apple 사용자 정리 (`apple_refresh_token` NULL 사용자는 탈퇴 시 500 발생)

<br>

## 관련 이슈
- Refs #74 

<br>