### PR TITLE
Fix(auth): Apple .p8 Private Key의 \n escape 복원 처리 (#78)

### DIFF
--- a/src/main/java/com/gemmap/gemmap/auth/infrastructure/oauth/AppleOAuth2Service.java
+++ b/src/main/java/com/gemmap/gemmap/auth/infrastructure/oauth/AppleOAuth2Service.java
@@ -234,6 +234,7 @@ public class AppleOAuth2Service {
         }
         try {
             String pem = privateKeyPem
+                    .replace("\\n", "\n")
                     .replace("-----BEGIN PRIVATE KEY-----", "")
                     .replace("-----END PRIVATE KEY-----", "")
                     .replaceAll("\\s", "");


### PR DESCRIPTION
## 요약
EC2 배포 환경에서 `APPLE_PRIVATE_KEY` 환경변수의 `\n` escape 문자열이 LF로 변환되지 않아  `AppleOAuth2Service.loadPrivateKey()`의 Base64 디코딩이 `Illegal base64 character 5c`(백슬래시)로 실패하던 버그를 수정함.

<br>

## 작업 내용
- `AppleOAuth2Service.loadPrivateKey()` 정제 chain 맨 앞에 `.replace("\\n", "\n")` 한 줄 추가
- 환경변수에 `\n` escape (백슬래시+n)가 포함된 경우 실제 LF로 복원 → 기존 `replaceAll("\\s", "")`가 정상적으로 줄바꿈 제거 → Base64 디코딩 성공
- 환경변수에 escape가 없는 경우(로컬 multiline PEM) 매칭되지 않아 no-op → **멱등 보장**

<br>

## 참고 사항
3안 비교 후 채택:
| 방식 | 변경 범위 | 채택 |
|------|----------|------|
| A. 코드 한 줄 수정 | Java 1파일 1줄 | ✅ |
| B. CD에서 base64 이중 인코딩 → 파일 복원 | CD + Compose 볼륨 + Spring 설정 + Java | 기각 |
| C. CD heredoc multiline secret을 파일로 직접 기록 | CD + Compose 볼륨 + Spring 설정 + Java | 기각 |

A는 로컬 multiline / 운영 `\n` escape 모두에서 멱등 동작하며, 향후 K8s Secret · AWS Secrets Manager 같은 multiline 친화 환경으로 이전해도 코드 변경 없이 동작함.
<br>  

GitHub Secrets 운영 가이드 (재확인):  
- `APPLE_PRIVATE_KEY`는 `\n` escape 한 줄 문자열로 저장 유지
- footer 뒤에 별도 `=` 추가 금지 (PEM 내부 padding `==`은 OK)

<br>

## 관련 이슈
- Closes #78

<br>