### PR TITLE
Fix(auth): 탈퇴 후 재로그인 시 유니크 제약 위반 해소 (#80)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,8 @@ nul
 
 # Document
 docs
+worklog
+portfolio
 
 # Postman
 .postman/

--- a/src/main/java/com/gemmap/gemmap/auth/application/service/AppleLoginTransactionService.java
+++ b/src/main/java/com/gemmap/gemmap/auth/application/service/AppleLoginTransactionService.java
@@ -11,14 +11,24 @@ import com.gemmap.gemmap.shared.exception.CommonException;
 import com.gemmap.gemmap.shared.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.Optional;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class AppleLoginTransactionService {
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
+    @Value("${withdraw.rejoin-grace-period-days:30}")
+    private int rejoinGracePeriodDays;
 
     private final UserRepository userRepository;
     private final JwtUtil jwtUtil;
@@ -50,8 +60,43 @@ public class AppleLoginTransactionService {
             throw new CommonException(ErrorCode.INVALID_INPUT_VALUE);
         }
 
-        return userRepository.findBySocialIdAndProvider(socialId, EProvider.APPLE)
-                .orElseGet(() -> createAppleUser(socialId, email, name));
+        // 1) 활성 사용자 조회
+        Optional<User> activeUser = userRepository.findBySocialIdAndProvider(socialId, EProvider.APPLE);
+        if (activeUser.isPresent()) {
+            return activeUser.get();
+        }
+
+        // 2) soft-deleted 사용자 조회 → 재가입 분기
+        //    Apple 공식 동작상 재로그인 시 name/email은 null로 와도 정상.
+        //    복구 경로에서는 validateAppleSignupInfo 우회 + 기존 DB 값 유지.
+        Optional<User> softDeleted = userRepository.findSoftDeletedBySocialIdAndProvider(socialId, EProvider.APPLE);
+        if (softDeleted.isPresent()) {
+            User user = softDeleted.get();
+            LocalDate originalDeleteDate = user.getDeleteDate();   // recoverUser() 전에 보관
+            boolean expired = isGracePeriodExpired(originalDeleteDate);
+
+            user.recoverUser();
+            // Apple은 복구 경로에서 email/name 갱신하지 않음 (Apple SDK가 재로그인 시 제공 안 함 — 공식 동작)
+            if (expired) {
+                user.resetForRejoin();
+                log.info("Apple 재가입 — 유예 경과 초기화: socialId={}, originalDeleteDate={}", socialId, originalDeleteDate);
+            } else {
+                log.info("Apple 재가입 — 유예 내 복구: socialId={}, originalDeleteDate={}", socialId, originalDeleteDate);
+            }
+            return user;   // @Transactional 영속 컨텍스트가 변경 자동 반영
+        }
+
+        // 3) 완전 신규 가입
+        return createAppleUser(socialId, email, name);
+    }
+
+    private boolean isGracePeriodExpired(LocalDate deleteDate) {
+        if (deleteDate == null) {
+            log.warn("soft-deleted Apple 사용자의 delete_date가 null — 데이터 정합성 점검 필요. 유예 경과로 간주");
+            return true;
+        }
+        LocalDate today = LocalDate.now(KST);
+        return today.isAfter(deleteDate.plusDays(rejoinGracePeriodDays));
     }
 
     private User createAppleUser(String socialId, String email, String name) {

--- a/src/main/java/com/gemmap/gemmap/auth/application/service/AppleLoginTransactionService.java
+++ b/src/main/java/com/gemmap/gemmap/auth/application/service/AppleLoginTransactionService.java
@@ -17,15 +17,12 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
-import java.time.ZoneId;
 import java.util.Optional;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class AppleLoginTransactionService {
-
-    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
 
     @Value("${withdraw.rejoin-grace-period-days:30}")
     private int rejoinGracePeriodDays;
@@ -73,7 +70,10 @@ public class AppleLoginTransactionService {
         if (softDeleted.isPresent()) {
             User user = softDeleted.get();
             LocalDate originalDeleteDate = user.getDeleteDate();   // recoverUser() 전에 보관
-            boolean expired = isGracePeriodExpired(originalDeleteDate);
+            if (originalDeleteDate == null) {
+                log.warn("soft-deleted Apple 사용자의 delete_date가 null — 데이터 정합성 점검 필요. 유예 경과로 간주");
+            }
+            boolean expired = user.isGracePeriodExpired(rejoinGracePeriodDays);
 
             user.recoverUser();
             // Apple은 복구 경로에서 email/name 갱신하지 않음 (Apple SDK가 재로그인 시 제공 안 함 — 공식 동작)
@@ -90,14 +90,6 @@ public class AppleLoginTransactionService {
         return createAppleUser(socialId, email, name);
     }
 
-    private boolean isGracePeriodExpired(LocalDate deleteDate) {
-        if (deleteDate == null) {
-            log.warn("soft-deleted Apple 사용자의 delete_date가 null — 데이터 정합성 점검 필요. 유예 경과로 간주");
-            return true;
-        }
-        LocalDate today = LocalDate.now(KST);
-        return today.isAfter(deleteDate.plusDays(rejoinGracePeriodDays));
-    }
 
     private User createAppleUser(String socialId, String email, String name) {
         validateAppleSignupInfo(email, name);

--- a/src/main/java/com/gemmap/gemmap/auth/application/service/AuthService.java
+++ b/src/main/java/com/gemmap/gemmap/auth/application/service/AuthService.java
@@ -25,6 +25,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.security.crypto.encrypt.TextEncryptor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -50,6 +52,9 @@ import java.util.UUID;
 public class AuthService {
 
     private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
+    @Value("${withdraw.rejoin-grace-period-days:30}")
+    private int rejoinGracePeriodDays;
 
     private final UserRepository userRepository;
     private final JwtUtil jwtUtil;
@@ -152,27 +157,59 @@ public class AuthService {
             throw new CommonException(ErrorCode.INVALID_INPUT_VALUE);
         }
 
-        try {
-            Optional<User> userOpt = userRepository.findBySocialIdAndProvider(socialId, EProvider.KAKAO);
-
-            if (userOpt.isPresent()) {
-                User existingUser = userOpt.get();
-                // 기존 사용자의 카카오 정보 업데이트
-                updateKakaoUserInfo(existingUser, userInfo);
-                User savedUser = userRepository.save(existingUser);
-                log.info("기존 카카오 사용자 정보 업데이트 - 사용자 ID: {}", savedUser.getId());
-                return savedUser;
-            }
-
-            // 신규 사용자 생성
-            User newUser = createKakaoUser(socialId, email, userInfo);
-            User savedUser = userRepository.save(newUser);
-            log.info("신규 카카오 사용자 생성 - 소셜 ID: {}, 사용자 ID: {}", socialId, savedUser.getId());
-            return savedUser;
-        } catch (Exception e) {
-            log.error("카카오 사용자 처리 중 오류: {}", e.getMessage(), e);
-            throw new CommonException(ErrorCode.DATABASE_ERROR);
+        // 1) 활성 사용자 조회 → 기존 로그인
+        Optional<User> activeUser = userRepository.findBySocialIdAndProvider(socialId, EProvider.KAKAO);
+        if (activeUser.isPresent()) {
+            User existing = activeUser.get();
+            updateKakaoUserInfo(existing, userInfo);
+            User saved = userRepository.save(existing);
+            log.info("기존 카카오 사용자 정보 업데이트 - 사용자 ID: {}", saved.getId());
+            return saved;
         }
+
+        // 2) soft-deleted 사용자 조회 → 재가입 분기
+        Optional<User> softDeleted = userRepository.findSoftDeletedBySocialIdAndProvider(socialId, EProvider.KAKAO);
+        if (softDeleted.isPresent()) {
+            User user = softDeleted.get();
+            LocalDate originalDeleteDate = user.getDeleteDate();   // recoverUser() 전에 보관
+            boolean expired = isGracePeriodExpired(originalDeleteDate);
+
+            user.recoverUser();
+            updateKakaoUserInfo(user, userInfo);   // 소셜 리니어블 최신화 먼저
+
+            if (expired) {
+                user.resetForRejoin();              // 마지막에 권한·임의 프로필 초기화
+                log.info("카카오 재가입 — 유예 경과 초기화: socialId={}, originalDeleteDate={}", socialId, originalDeleteDate);
+            } else {
+                log.info("카카오 재가입 — 유예 내 복구: socialId={}, originalDeleteDate={}", socialId, originalDeleteDate);
+            }
+            return userRepository.save(user);
+        }
+
+        // 3) 완전 신규 가입
+        try {
+            User newUser = createKakaoUser(socialId, email, userInfo);
+            User saved = userRepository.save(newUser);
+            log.info("신규 카카오 사용자 생성 - 소셜 ID: {}, 사용자 ID: {}", socialId, saved.getId());
+            return saved;
+        } catch (DataIntegrityViolationException e) {
+            // 동시 재로그인 충돌 시 재조회로 수렴 (Apple 패턴 일관 적용)
+            log.warn("카카오 사용자 동시 생성 충돌 - socialId: {}. 활성/탈퇴 재조회", socialId);
+            return userRepository.findBySocialIdAndProvider(socialId, EProvider.KAKAO)
+                    .or(() -> userRepository.findSoftDeletedBySocialIdAndProvider(socialId, EProvider.KAKAO))
+                    .orElseThrow(() -> new CommonException(ErrorCode.DATABASE_ERROR));
+        }
+    }
+
+    private boolean isGracePeriodExpired(LocalDate deleteDate) {
+        if (deleteDate == null) {
+            // soft-deleted인데 deleteDate가 NULL인 비정상 상태 → 데이터 정합성 점검 필요
+            // 안전한 fallback: 유예 경과로 간주하여 초기화 처리
+            log.warn("soft-deleted 사용자의 delete_date가 null — 데이터 정합성 점검 필요. 유예 경과로 간주");
+            return true;
+        }
+        LocalDate today = LocalDate.now(KST);
+        return today.isAfter(deleteDate.plusDays(rejoinGracePeriodDays));
     }
 
     /**
@@ -234,6 +271,10 @@ public class AuthService {
                 birthday,
                 birthyear
         );
+
+        // FR-3: 소셜 최신 email 갱신 (기존 updateKakaoUserInfo는 email을 다루지 않음)
+        String email = account != null ? account.getEmail() : null;
+        user.updateEmail(email);
     }
 
     /**

--- a/src/main/java/com/gemmap/gemmap/auth/application/service/AuthService.java
+++ b/src/main/java/com/gemmap/gemmap/auth/application/service/AuthService.java
@@ -172,7 +172,10 @@ public class AuthService {
         if (softDeleted.isPresent()) {
             User user = softDeleted.get();
             LocalDate originalDeleteDate = user.getDeleteDate();   // recoverUser() 전에 보관
-            boolean expired = isGracePeriodExpired(originalDeleteDate);
+            if (originalDeleteDate == null) {
+                log.warn("soft-deleted 사용자의 delete_date가 null — 데이터 정합성 점검 필요. 유예 경과로 간주");
+            }
+            boolean expired = user.isGracePeriodExpired(rejoinGracePeriodDays);
 
             user.recoverUser();
             updateKakaoUserInfo(user, userInfo);   // 소셜 리니어블 최신화 먼저
@@ -201,16 +204,6 @@ public class AuthService {
         }
     }
 
-    private boolean isGracePeriodExpired(LocalDate deleteDate) {
-        if (deleteDate == null) {
-            // soft-deleted인데 deleteDate가 NULL인 비정상 상태 → 데이터 정합성 점검 필요
-            // 안전한 fallback: 유예 경과로 간주하여 초기화 처리
-            log.warn("soft-deleted 사용자의 delete_date가 null — 데이터 정합성 점검 필요. 유예 경과로 간주");
-            return true;
-        }
-        LocalDate today = LocalDate.now(KST);
-        return today.isAfter(deleteDate.plusDays(rejoinGracePeriodDays));
-    }
 
     /**
      * 카카오 사용자 생성

--- a/src/main/java/com/gemmap/gemmap/auth/domain/entity/User.java
+++ b/src/main/java/com/gemmap/gemmap/auth/domain/entity/User.java
@@ -213,6 +213,18 @@ public class User {
         }
     }
 
+    /**
+     * 탈퇴 유예 기간 만료 여부.
+     * deleteDate가 null인 비정상 상태는 유예 경과로 간주(안전한 fallback).
+     */
+    public boolean isGracePeriodExpired(int gracePeriodDays) {
+        if (this.deleteDate == null) {
+            return true;
+        }
+        LocalDate today = LocalDate.now(KST);
+        return today.isAfter(this.deleteDate.plusDays(gracePeriodDays));
+    }
+
     public void agreeToPhotoConsent() {
         this.photoConsentAgreedAt = LocalDateTime.now(KST);
     }

--- a/src/main/java/com/gemmap/gemmap/auth/domain/entity/User.java
+++ b/src/main/java/com/gemmap/gemmap/auth/domain/entity/User.java
@@ -191,6 +191,28 @@ public class User {
         this.deleteDate = null;
     }
 
+    /**
+     * 유예 기간(30일) 경과 후 재가입 시 권한·임의 프로필 초기화.
+     * 소셜 리니어블 필드(email, name, gender, ageRange, birthday, birthyear)는 별도 갱신.
+     * 연관 데이터(spot/bookmark/checkin/photo/report)는 본 스코프 외.
+     */
+    public void resetForRejoin() {
+        this.role = ERole.GUEST;
+        this.nickname = null;
+        this.profileImage = Constant.DEFAULT_PROFILE_IMAGE;
+        this.photoConsentAgreedAt = null;
+    }
+
+    /**
+     * 소셜 제공자에서 받은 최신 email로 갱신.
+     * 기존 updateKakaoUserInfo가 email을 다루지 않아 별도 메서드로 분리.
+     */
+    public void updateEmail(String email) {
+        if (email != null && !email.isBlank()) {
+            this.email = email;
+        }
+    }
+
     public void agreeToPhotoConsent() {
         this.photoConsentAgreedAt = LocalDateTime.now(KST);
     }

--- a/src/main/java/com/gemmap/gemmap/auth/domain/repository/UserRepository.java
+++ b/src/main/java/com/gemmap/gemmap/auth/domain/repository/UserRepository.java
@@ -33,6 +33,9 @@ public interface UserRepository extends JpaRepository<User, Long> {
     @Query("SELECT u FROM User u WHERE u.socialId = :socialId AND u.eProvider = :provider AND u.isDeleted = false")
     Optional<User> findBySocialIdAndProvider(String socialId, EProvider provider);
 
+    @Query("SELECT u FROM User u WHERE u.socialId = :socialId AND u.eProvider = :provider AND u.isDeleted = true")
+    Optional<User> findSoftDeletedBySocialIdAndProvider(String socialId, EProvider provider);
+
     @Query("SELECT u FROM User u WHERE u.email = :email AND u.isDeleted = false")
     Optional<User> findByEmail(String email);
 

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -57,3 +57,7 @@ s3:
   base-path: "test/"
   spot-base-path: "test/spots/"
   checkin-base-path: "test/checkins/"
+
+# 회원 탈퇴 후 재가입 정책 (테스트용)
+withdraw:
+  rejoin-grace-period-days: 30

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -51,6 +51,10 @@ crypto:
     enc-password: ${APPLE_REFRESH_TOKEN_ENC_PASSWORD}
     enc-salt: ${APPLE_REFRESH_TOKEN_ENC_SALT}
 
+# 회원 탈퇴 후 재가입 정책
+withdraw:
+  rejoin-grace-period-days: 30   # 탈퇴 후 N일 이내 재로그인 → 데이터 유지 복구. 경과 시 권한·프로필 초기화
+
 # AWS S3 설정
 s3:
   region:


### PR DESCRIPTION
## 요약
회원 탈퇴(`#74`) 후 동일 소셜 계정으로 재로그인 시 발생하던 **유니크 제약 위반 500 오류**(`Duplicate entry 'social_id-PROVIDER'`)를 해소하고, 유예 30일 기반 재가입 정책을 도입함. (임시)

<br>

## 작업 내용
- `UserRepository.findSoftDeletedBySocialIdAndProvider` 신규 쿼리 추가 (기존 활성 조회는 미변경 → 회귀 0)
- `AuthService.findOrCreateKakaoUser` / `AppleLoginTransactionService.findOrCreateAppleUser` 를 3+1분기(활성 / 유예 30일 내 / 유예 경과 / 완전 신규)로 재작성
- `User.resetForRejoin()` (role=GUEST, nickname/profileImage/photoConsent 초기화) + `User.updateEmail()` 신규 메서드
- `AuthService.updateKakaoUserInfo`(private)에 email 갱신 한 줄 추가
- Kakao 광범위 `catch (Exception e)` 제거 → `DataIntegrityViolationException`만 명시 catch (Apple 패턴 일관 적용, dead code 방지)
- Apple 복구 경로는 `validateAppleSignupInfo` 우회 ([Apple 공식 동작](https://developer.apple.com/forums/thread/735739) — revoke 후 재로그인 시 fullName 미제공)
- `application.yml`: `withdraw.rejoin-grace-period-days: 30` 추가

<br>

## 참고 사항
핵심 설계 결정
- **레코드 재활용**: 유예 30일 경과 시에도 같은 user.id 재사용 + 권한·프로필 초기화. **사유**: User→자식 FK 5개(`Spot`/`SpotBookmark`/`SpotCheckin`/`SpotPhoto`/`SpotReport`)가 모두 `nullable=false` + CASCADE 미설정 → 물리 삭제 비용이 본 스코프(로그인 버그 해결) 초과
- **유예 판정 순서**: `recoverUser()` 호출 **전** `originalDeleteDate` 보관 (`recoverUser`가 `deleteDate=null`로 변경하므로 순서 의존)
- **Kakao 분기 호출 순서**: `updateKakaoUserInfo` → `resetForRejoin` (역순이면 `resetForRejoin` 효과가 즉시 깨짐)  

후속 이슈 (별도 분리)
- 유예 30일 경과 user row 물리 삭제 + 연관 데이터 cascade 정리 + `deleteUsersByDeleteDate` 배치 활성화
- `DataIntegrityViolationException` 트랜잭션 분리 리팩토링 (Kakao + Apple 양쪽 `REQUIRES_NEW`)  

운영 검증 필요
- 30일 경계값 동작 (Kakao/Apple)
- 동시 재로그인 통합 테스트 — `UnexpectedRollbackException` 사용자 노출 없는지 실측 (Spring 공식 문서상 같은 트랜잭션 catch 후 진행 비권장. 실패 확인 시 후속 트랜잭션 분리 작업 우선순위 상향)
- `deleteDate=null` 비정상 row warn 로그 + 유예 경과 처리 확인

<br>

## 관련 이슈
- Closes #80

<br>