### PR TITLE
Feat(auth): 사진 정보 활용 동의 철회(Revoke) 기능 추가

### DIFF
--- a/src/main/java/com/gemmap/gemmap/auth/application/dto/request/PhotoConsentRequest.java
+++ b/src/main/java/com/gemmap/gemmap/auth/application/dto/request/PhotoConsentRequest.java
@@ -1,0 +1,17 @@
+package com.gemmap.gemmap.auth.application.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * 사진 정보 활용 동의/철회 요청 Body DTO.
+ * agreed=true  → 동의 처리 (멱등: 이미 동의면 시각 보존)
+ * agreed=false → 철회 처리 (멱등: 이미 미동의/철회면 변경 없음)
+ *
+ * Boolean 래퍼 사용 — 원시 boolean 은 JSON null 을 false 로 역직렬화하여
+ * @NotNull 검증이 무효화될 수 있다. (01_구현_설계.md §2-4 참조)
+ */
+public record PhotoConsentRequest(
+        @NotNull(message = "agreed 필드는 필수입니다.")
+        Boolean agreed
+) {
+}

--- a/src/main/java/com/gemmap/gemmap/auth/application/service/AuthService.java
+++ b/src/main/java/com/gemmap/gemmap/auth/application/service/AuthService.java
@@ -612,17 +612,24 @@ public class AuthService {
     }
 
     /**
-     * 사진 정보 활용 동의 처리 (멱등)
-     * - 미동의 → 동의 처리 후 true 반환
-     * - 기동의 → 추가 처리 없이 true 반환 (409 아님)
+     * 사진 정보 활용 동의/철회 처리 (양방향 멱등).
+     * agreed=true  → 미동의면 시각 기록, 기동의면 시각 보존.
+     * agreed=false → 동의 상태면 시각 null 초기화(철회), 미동의면 변경 없음.
+     * 동일 상태 유지 요청은 no-op 분기로 UPDATE 가 발생하지 않는다.
      */
     @Transactional
-    public PhotoConsentResponse agreeToPhotoConsent(Long userId) {
+    public PhotoConsentResponse setPhotoConsent(Long userId, boolean agreed) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CommonException(ErrorCode.USER_NOT_FOUND));
 
-        if (!user.hasPhotoConsentAgreed()) {
-            user.agreeToPhotoConsent();
+        if (agreed) {
+            if (!user.hasPhotoConsentAgreed()) {
+                user.agreeToPhotoConsent();
+            }
+        } else {
+            if (user.hasPhotoConsentAgreed()) {
+                user.revokePhotoConsent();
+            }
         }
 
         return PhotoConsentResponse.of(user.hasPhotoConsentAgreed());

--- a/src/main/java/com/gemmap/gemmap/auth/domain/entity/User.java
+++ b/src/main/java/com/gemmap/gemmap/auth/domain/entity/User.java
@@ -72,6 +72,12 @@ public class User {
     @Column(name = "delete_date")
     private LocalDate deleteDate;
 
+    /**
+     * 사진 정보 활용 동의 시각.
+     * non-null: 동의 상태 (마지막 동의 시점)
+     * null    : 미동의 또는 철회 완료
+     * 단일 필드 정책 — 별도 철회 시각 컬럼 두지 않음. 판정은 {@link #hasPhotoConsentAgreed()}.
+     */
     @Column(name = "photo_consent_agreed_at")
     private LocalDateTime photoConsentAgreedAt;
 
@@ -227,6 +233,16 @@ public class User {
 
     public void agreeToPhotoConsent() {
         this.photoConsentAgreedAt = LocalDateTime.now(KST);
+    }
+
+    /**
+     * 사진 정보 활용 동의 철회.
+     * 단일 필드 정책에 따라 동의 시각을 null 로 초기화한다.
+     * 호출부(SpotService/CheckinService) 의 {@link #hasPhotoConsentAgreed()} 검증식은 무변경 —
+     * 철회 사용자는 photoConsentAgreedAt == null 이 되어 자동 미동의 처리된다.
+     */
+    public void revokePhotoConsent() {
+        this.photoConsentAgreedAt = null;
     }
 
     public boolean hasPhotoConsentAgreed() {

--- a/src/main/java/com/gemmap/gemmap/auth/presentation/AuthController.java
+++ b/src/main/java/com/gemmap/gemmap/auth/presentation/AuthController.java
@@ -1,6 +1,7 @@
 package com.gemmap.gemmap.auth.presentation;
 
 import com.gemmap.gemmap.auth.application.dto.request.AppleLoginRequestDto;
+import com.gemmap.gemmap.auth.application.dto.request.PhotoConsentRequest;
 import com.gemmap.gemmap.auth.application.dto.response.PhotoConsentResponse;
 import com.gemmap.gemmap.auth.application.dto.response.RegisterResponseDto;
 import com.gemmap.gemmap.auth.application.dto.response.SocialLoginResponseDto;
@@ -125,12 +126,16 @@ public class AuthController {
     }
 
     /**
-     * 사진 정보 활용 동의 처리
+     * 사진 정보 활용 동의/철회 처리 (양방향 멱등)
      * POST /api/v1/auth/photo-consent
+     * Body: { "agreed": boolean }  // 필수
      */
     @PostMapping("/photo-consent")
-    public ResponseEntity<PhotoConsentResponse> agreeToPhotoConsent(@UserId Long userId) {
-        return ResponseEntity.ok(authService.agreeToPhotoConsent(userId));
+    public ResponseEntity<PhotoConsentResponse> setPhotoConsent(
+            @UserId Long userId,
+            @Valid @RequestBody PhotoConsentRequest request
+    ) {
+        return ResponseEntity.ok(authService.setPhotoConsent(userId, request.agreed()));
     }
 
     /**

--- a/src/test/java/com/gemmap/gemmap/auth/application/service/AuthServicePhotoConsentTest.java
+++ b/src/test/java/com/gemmap/gemmap/auth/application/service/AuthServicePhotoConsentTest.java
@@ -1,0 +1,165 @@
+package com.gemmap.gemmap.auth.application.service;
+
+import com.gemmap.gemmap.auth.application.dto.response.PhotoConsentResponse;
+import com.gemmap.gemmap.auth.domain.entity.User;
+import com.gemmap.gemmap.auth.domain.repository.UserRepository;
+import com.gemmap.gemmap.auth.infrastructure.jwt.JwtUtil;
+import com.gemmap.gemmap.auth.infrastructure.oauth.AppleOAuth2Service;
+import com.gemmap.gemmap.auth.infrastructure.oauth.KakaoOAuth2Service;
+import com.gemmap.gemmap.shared.config.s3.S3Properties;
+import com.gemmap.gemmap.shared.exception.CommonException;
+import com.gemmap.gemmap.shared.exception.ErrorCode;
+import com.gemmap.gemmap.shared.infrastructure.objectstorage.ObjectStorageService;
+import com.gemmap.gemmap.shared.infrastructure.objectstorage.S3PresignedUrlService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.encrypt.TextEncryptor;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+/**
+ * {@link AuthService#setPhotoConsent(Long, boolean)} 단위 테스트.
+ *
+ * 본 기능(worklog/16_photo_consent_revoke) 에서 추가된 양방향 멱등 분기를 검증한다.
+ * AuthService 의 다른 메서드(OAuth, JWT 등) 와는 분리하여 본 책임만 다룬다.
+ */
+@ExtendWith(MockitoExtension.class)
+class AuthServicePhotoConsentTest {
+
+    private static final Long TEST_USER_ID = 1L;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private JwtUtil jwtUtil;
+
+    @Mock
+    private KakaoOAuth2Service kakaoOAuth2Service;
+
+    @Mock
+    private AppleOAuth2Service appleOAuth2Service;
+
+    @Mock
+    private AppleLoginTransactionService appleLoginTransactionService;
+
+    @Mock
+    private WithdrawTransactionService withdrawTransactionService;
+
+    @Mock
+    private TextEncryptor appleRefreshTokenEncryptor;
+
+    @Mock
+    private ObjectStorageService objectStorageService;
+
+    @Mock
+    private S3PresignedUrlService s3PresignedUrlService;
+
+    @Mock
+    private S3Properties s3Properties;
+
+    @InjectMocks
+    private AuthService authService;
+
+    @Nested
+    @DisplayName("setPhotoConsent — agreed=true (동의)")
+    class AgreeCases {
+
+        @Test
+        @DisplayName("미동의 사용자가 동의 요청 시 agreeToPhotoConsent() 호출 + 응답 agreed=true")
+        void agreeWhenNotConsented() {
+            // given
+            User user = mock(User.class);
+            given(userRepository.findById(TEST_USER_ID)).willReturn(Optional.of(user));
+            given(user.hasPhotoConsentAgreed()).willReturn(false, true);
+
+            // when
+            PhotoConsentResponse response = authService.setPhotoConsent(TEST_USER_ID, true);
+
+            // then
+            verify(user).agreeToPhotoConsent();
+            verify(user, never()).revokePhotoConsent();
+            assertThat(response.agreed()).isTrue();
+        }
+
+        @Test
+        @DisplayName("이미 동의한 사용자 재요청 시 agreeToPhotoConsent() 호출 없음 (멱등) + 응답 agreed=true")
+        void agreeWhenAlreadyConsented() {
+            // given
+            User user = mock(User.class);
+            given(userRepository.findById(TEST_USER_ID)).willReturn(Optional.of(user));
+            given(user.hasPhotoConsentAgreed()).willReturn(true);
+
+            // when
+            PhotoConsentResponse response = authService.setPhotoConsent(TEST_USER_ID, true);
+
+            // then
+            verify(user, never()).agreeToPhotoConsent();
+            verify(user, never()).revokePhotoConsent();
+            assertThat(response.agreed()).isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("setPhotoConsent — agreed=false (철회)")
+    class RevokeCases {
+
+        @Test
+        @DisplayName("동의 사용자가 철회 요청 시 revokePhotoConsent() 호출 + 응답 agreed=false")
+        void revokeWhenConsented() {
+            // given
+            User user = mock(User.class);
+            given(userRepository.findById(TEST_USER_ID)).willReturn(Optional.of(user));
+            given(user.hasPhotoConsentAgreed()).willReturn(true, false);
+
+            // when
+            PhotoConsentResponse response = authService.setPhotoConsent(TEST_USER_ID, false);
+
+            // then
+            verify(user).revokePhotoConsent();
+            verify(user, never()).agreeToPhotoConsent();
+            assertThat(response.agreed()).isFalse();
+        }
+
+        @Test
+        @DisplayName("미동의/철회 사용자가 철회 재요청 시 revokePhotoConsent() 호출 없음 (멱등) + 응답 agreed=false")
+        void revokeWhenAlreadyNotConsented() {
+            // given
+            User user = mock(User.class);
+            given(userRepository.findById(TEST_USER_ID)).willReturn(Optional.of(user));
+            given(user.hasPhotoConsentAgreed()).willReturn(false);
+
+            // when
+            PhotoConsentResponse response = authService.setPhotoConsent(TEST_USER_ID, false);
+
+            // then
+            verify(user, never()).agreeToPhotoConsent();
+            verify(user, never()).revokePhotoConsent();
+            assertThat(response.agreed()).isFalse();
+        }
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 userId 로 호출 시 USER_NOT_FOUND 예외")
+    void userNotFound() {
+        // given
+        given(userRepository.findById(TEST_USER_ID)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> authService.setPhotoConsent(TEST_USER_ID, true))
+                .isInstanceOf(CommonException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.USER_NOT_FOUND);
+    }
+}


### PR DESCRIPTION
## 요약
기존 `POST /api/v1/auth/photo-consent` 엔드포인트에 Request Body `{ "agreed": boolean }` 을 추가하여 동의(`true`) / 철회(`false`) 양방향 처리를 지원함.  
철회 시 `User.photoConsentAgreedAt` 을 `null` 로 초기화하여, 다음 사진 업로드 진입 시 다시 `403 PHOTO_CONSENT_REQUIRED` 가 반환되도록 함.

<br>

## 작업 내용
- `POST /api/v1/auth/photo-consent` 에 Body `{ "agreed": boolean }` **필수 필드** 추가 (`@NotNull Boolean`)
- 동의(`true`) / 철회(`false`) **양방향 멱등** 처리 — 동일 상태 유지 요청은 시각 덮어쓰지 않음
- `User.revokePhotoConsent()` 도메인 메서드 추가 (단일 필드 정책: `photoConsentAgreedAt = null`)
- `PhotoConsentRequest` record 신규 생성
- `AuthService.agreeToPhotoConsent(Long)` → `setPhotoConsent(Long, boolean)` 시그니처 변경
- `AuthServicePhotoConsentTest` 단위 테스트 5건 추가 (양방향 멱등 4건 + `USER_NOT_FOUND` 1건, 모두 PASSED)
- `SpotService` / `CheckinService` 호출부 무변경 (`hasPhotoConsentAgreed()` 판정식 유지)

<br>

## 참고 사항
- **클라이언트 재배포 필요**: 기존 무바디 호출은 더 이상 지원하지 않습니다 (Body 필수화 정책으로 `400 INVALID_INPUT_VALUE` 반환). iOS·Android 배포와 동기화 필요.
- **Jackson 기본 coercion 수용**: `{"agreed": 1}` 은 `true`, `{"agreed": 0}` 은 `false` 로 정상 처리(200). Jackson 2.19.2 의 표준 boolean coercion 동작을 그대로 수용.
- **동시성 정책**: 동일 user 의 agree/revoke 동시 요청은 `last-commit-wins` (강한 순서 보장 없음).

<br>

## 관련 이슈
- Closes #82 

<br>