### PR TITLE
Fix(spot): 스팟 삭제 시 TransientObjectException 해소 및 자식 FK CASCADE 정리

### DIFF
--- a/src/main/java/com/gemmap/gemmap/checkin/domain/entity/SpotCheckin.java
+++ b/src/main/java/com/gemmap/gemmap/checkin/domain/entity/SpotCheckin.java
@@ -7,6 +7,8 @@ import com.gemmap.gemmap.spot.domain.entity.SpotPhoto;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 import java.time.LocalDateTime;
 
@@ -31,10 +33,12 @@ public class SpotCheckin {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "spot_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Spot spot;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "photo_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private SpotPhoto photo;
 
     @Column(name = "recommendation_level", nullable = false)

--- a/src/main/java/com/gemmap/gemmap/spot/application/service/SpotService.java
+++ b/src/main/java/com/gemmap/gemmap/spot/application/service/SpotService.java
@@ -4,7 +4,6 @@ import com.gemmap.gemmap.auth.domain.entity.User;
 import com.gemmap.gemmap.auth.domain.repository.UserRepository;
 import com.gemmap.gemmap.bookmark.application.service.BookmarkService;
 import com.gemmap.gemmap.checkin.application.service.CheckinService;
-import com.gemmap.gemmap.checkin.domain.repository.SpotCheckinRepository;
 import com.gemmap.gemmap.shared.common.enums.ERecommendationLevel;
 import com.gemmap.gemmap.shared.infrastructure.objectstorage.ObjectStorageService;
 import com.gemmap.gemmap.shared.infrastructure.objectstorage.S3PresignedUrlService;
@@ -28,6 +27,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.math.BigDecimal;
@@ -143,39 +144,52 @@ public class SpotService {
     }
 
     /**
-     * 스팟 삭제 (DB 우선 삭제 후 Object Storage 삭제)
+     * 스팟 삭제
      *
-     * @param userId 요청 사용자 ID
-     * @param spotId 삭제할 스팟 ID
+     * DB 자식 데이터는 FK ON DELETE CASCADE로 정리되며, S3 객체는 트랜잭션 커밋 성공 후 삭제한다.
      */
     @Transactional
     public void delete(Long userId, Long spotId) {
-        // 1) 사용자 조회
-        User user = userRepository.findById(userId)
+        // 1) 사용자 존재 검증 — 토큰 잔존 등의 비정상 케이스 방어 (반환 객체는 사용하지 않음)
+        userRepository.findById(userId)
                 .orElseThrow(() -> new CommonException(ErrorCode.USER_NOT_FOUND));
 
         // 2) Spot 존재 확인
         Spot spot = spotRepository.findById(spotId)
             .orElseThrow(() -> new CommonException(ErrorCode.SPOT_NOT_FOUND));
 
-        // 3) 소유권 검증
-        if (!spot.getUser().equals(user)) {
+        // 3) 소유권 검증 — ID 비교로 영속성 컨텍스트 1차 캐시 의존을 제거.
+        //    spot.getUser()는 LAZY 프록시지만 getId()는 프록시 초기화 없이 식별자 반환
+        //    (Hibernate AbstractLazyInitializer 동작).
+        if (!spot.getUser().getId().equals(userId)) {
             throw new CommonException(ErrorCode.ACCESS_DENIED, "해당 스팟을 삭제할 권한이 없습니다.");
         }
 
-        // 4) 연결된 SpotPhoto 조회 (S3 key 추출용)
-        List<SpotPhoto> photos = spotPhotoRepository.findBySpot(spot);
-        List<String> keys = photos.stream()
-            .map(SpotPhoto::getFileUrl)
-            .toList();
+        // 4) S3 키 목록만 수집 (entity는 영속성 컨텍스트에 올리지 않음)
+        List<String> keys = spotPhotoRepository.findFileUrlsBySpot(spotId);
 
-        // 5) DB 삭제
+        // 5) DB 삭제 — 자식 4종은 FK ON DELETE CASCADE로 자동 정리됨
         spotRepository.delete(spot);
 
-        // 6) Object Storage 삭제 (트랜잭션 외부, 베스트 에포트)
-        for (String key : keys) {
-            S3FileUtils.safeDelete(objectStorageService, s3Properties, key);
+        // 6) S3 객체 삭제는 트랜잭션 commit 성공 후에만 수행 (rollback 시 S3 객체 보존)
+        if (!keys.isEmpty()) {
+            registerS3CleanupAfterCommit(keys);
         }
+    }
+
+    /**
+     * 트랜잭션 커밋 성공 후 S3 객체 삭제 콜백을 등록한다.
+     * 삭제 실패는 safeDelete 내부에서 처리되므로 응답 흐름에 영향을 주지 않는다.
+     */
+    private void registerS3CleanupAfterCommit(List<String> keys) {
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                for (String key : keys) {
+                    S3FileUtils.safeDelete(objectStorageService, s3Properties, key);
+                }
+            }
+        });
     }
 
     /**

--- a/src/main/java/com/gemmap/gemmap/spot/domain/repository/SpotPhotoRepository.java
+++ b/src/main/java/com/gemmap/gemmap/spot/domain/repository/SpotPhotoRepository.java
@@ -6,12 +6,22 @@ import com.gemmap.gemmap.spot.domain.entity.Spot;
 import com.gemmap.gemmap.spot.domain.entity.SpotPhoto;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
 
 public interface SpotPhotoRepository extends JpaRepository<SpotPhoto, Long> {
     List<SpotPhoto> findBySpot(Spot spot);
+
+    /**
+     * 특정 스팟에 속한 모든 SpotPhoto의 fileUrl(S3 키)만 조회한다.
+     *
+     * SpotPhoto 엔티티를 영속성 컨텍스트에 로드하지 않기 위한 projection 쿼리다.
+     * 스팟 삭제 시 S3 객체 정리를 위한 키 수집 용도로만 사용한다.
+     */
+    @Query("select sp.fileUrl from SpotPhoto sp where sp.spot.id = :spotId")
+    List<String> findFileUrlsBySpot(@Param("spotId") Long spotId);
 
     /**
      * 특정 스팟의 type이 SPOT인 대표 사진 조회 (최신 1건)

--- a/src/test/java/com/gemmap/gemmap/spot/application/service/SpotServiceDeleteIntegrationTest.java
+++ b/src/test/java/com/gemmap/gemmap/spot/application/service/SpotServiceDeleteIntegrationTest.java
@@ -1,0 +1,97 @@
+package com.gemmap.gemmap.spot.application.service;
+
+import com.gemmap.gemmap.auth.domain.entity.User;
+import com.gemmap.gemmap.auth.domain.repository.UserRepository;
+import com.gemmap.gemmap.shared.common.enums.EProvider;
+import com.gemmap.gemmap.shared.common.enums.ERole;
+import com.gemmap.gemmap.shared.config.s3.S3Properties;
+import com.gemmap.gemmap.shared.infrastructure.objectstorage.ObjectStorageService;
+import com.gemmap.gemmap.spot.domain.entity.Spot;
+import com.gemmap.gemmap.spot.domain.repository.SpotPhotoRepository;
+import com.gemmap.gemmap.spot.domain.repository.SpotRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.transaction.TestTransaction;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+/**
+ * SpotService.delete의 afterCommit 동작에 대한 실제 commit 기반 통합 검증.
+ *
+ * 단위 테스트(SpotServiceTest.DeleteTests)는 동기화 등록·콜백 본문까지만 검증한다.
+ * 본 통합 테스트는 Spring 트랜잭션 매니저가 실제 commit 경로에서 afterCommit을
+ * 호출하는지를 확인해 hotfix 핵심 보강(S3 삭제 afterCommit 이동)의 회귀를 막는다.
+ *
+ * SpotPhoto의 location 필드(POINT SRID 4326)는 H2에서 ORM persist가 불안하므로
+ * SpotPhotoRepository를 @MockBean으로 격리하고 findFileUrlsBySpot만 스텁한다.
+ * User/Spot은 실 DB(H2)에 persist.
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+class SpotServiceDeleteIntegrationTest {
+
+    @Autowired private SpotService spotService;
+    @Autowired private UserRepository userRepository;
+    @Autowired private SpotRepository spotRepository;
+    @Autowired private S3Properties s3Properties;                  // real bean (test-bucket 사용)
+    @MockBean private SpotPhotoRepository spotPhotoRepository;     // H2 spatial 우회
+    @MockBean private ObjectStorageService objectStorageService;   // S3 호출 격리
+
+    private static final String S3_KEY = "dev/spots/test/key.jpg";
+
+    @Test
+    @DisplayName("실제 commit 후 afterCommit 콜백이 발동되어 S3 객체 삭제가 호출된다")
+    void delete_realCommit_invokesS3CleanupAfterCommit() {
+        // Given: User + Spot fixture 영속 (SpotPhoto는 mock 스텁으로 대체)
+        User user = userRepository.save(buildTestUser());
+        Spot spot = spotRepository.save(buildTestSpot(user));
+
+        given(spotPhotoRepository.findFileUrlsBySpot(spot.getId()))
+            .willReturn(List.of(S3_KEY));
+
+        TestTransaction.flagForCommit();
+        TestTransaction.end();   // setUp 트랜잭션 종료 (commit)
+
+        // When: 새 트랜잭션에서 delete 호출 + commit
+        TestTransaction.start();
+        spotService.delete(user.getId(), spot.getId());
+        TestTransaction.flagForCommit();
+        TestTransaction.end();   // delete 트랜잭션 commit → afterCommit 발동
+
+        // Then: afterCommit 콜백이 실제로 호출되어 S3 mock 호출 발생
+        verify(objectStorageService).delete(eq(s3Properties.getBucket()), eq(S3_KEY));
+    }
+
+    private User buildTestUser() {
+        return User.builder()
+            .socialId("test-social-id")
+            .eProvider(EProvider.KAKAO)
+            .role(ERole.USER)
+            .email("test@example.com")
+            .name("테스트유저")
+            .nickname("tester")
+            .build();
+    }
+
+    private Spot buildTestSpot(User user) {
+        // Spot은 spatial 필드 없음 (sido/sigungu/fullAddress/shortAddress/alias만 NOT NULL)
+        return Spot.builder()
+            .user(user)
+            .sido("서울특별시")
+            .sigungu("강남구")
+            .fullAddress("대한민국 서울특별시 강남구 테스트로 1")
+            .shortAddress("서울특별시 강남구")
+            .alias("테스트스팟")
+            .build();
+    }
+}

--- a/src/test/java/com/gemmap/gemmap/spot/application/service/SpotServiceTest.java
+++ b/src/test/java/com/gemmap/gemmap/spot/application/service/SpotServiceTest.java
@@ -13,6 +13,7 @@ import com.gemmap.gemmap.spot.domain.entity.Spot;
 import com.gemmap.gemmap.spot.domain.entity.SpotPhoto;
 import com.gemmap.gemmap.spot.domain.repository.SpotPhotoRepository;
 import com.gemmap.gemmap.spot.domain.repository.SpotRepository;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -23,8 +24,11 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import java.math.BigDecimal;
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -236,6 +240,126 @@ class SpotServiceTest {
 
             verify(spotFileValidator, never()).validateImage(any());
             verify(objectStorageService, never()).upload(anyString(), anyString(), any());
+        }
+    }
+
+    // =====================================================================
+    // 스팟 삭제 검증 — TransientObjectException 해소 + DB FK CASCADE + afterCommit
+    // =====================================================================
+
+    @Nested
+    @DisplayName("스팟 삭제")
+    class DeleteTests {
+
+        private static final Long TEST_SPOT_ID = 100L;
+        private static final String S3_KEY_1 = "dev/spots/2026/05/uuid-1.jpg";
+        private static final String S3_KEY_2 = "dev/spots/2026/05/uuid-2.jpg";
+
+        @BeforeEach
+        void initTxSync() {
+            // 트랜잭션 동기화 라이프사이클을 테스트에서 직접 관리
+            // (실제 트랜잭션 없이 registerSynchronization 호출만 캡처)
+            if (!TransactionSynchronizationManager.isSynchronizationActive()) {
+                TransactionSynchronizationManager.initSynchronization();
+            }
+        }
+
+        @AfterEach
+        void clearTxSync() {
+            if (TransactionSynchronizationManager.isSynchronizationActive()) {
+                TransactionSynchronizationManager.clearSynchronization();
+            }
+        }
+
+        @Test
+        @DisplayName("스팟 삭제 → projection 호출 + Spot 삭제 + afterCommit 동기화 등록")
+        void delete_shouldCallProjectionAndDeleteSpotAndRegisterAfterCommit() {
+            // Given
+            Spot spot = mock(Spot.class);
+            given(userRepository.findById(TEST_USER_ID)).willReturn(Optional.of(testUser));
+            given(spotRepository.findById(TEST_SPOT_ID)).willReturn(Optional.of(spot));
+            given(spot.getUser()).willReturn(testUser);
+            given(spotPhotoRepository.findFileUrlsBySpot(TEST_SPOT_ID))
+                .willReturn(List.of(S3_KEY_1, S3_KEY_2));
+
+            // When
+            spotService.delete(TEST_USER_ID, TEST_SPOT_ID);
+
+            // Then
+            verify(spotPhotoRepository).findFileUrlsBySpot(TEST_SPOT_ID);
+            verify(spotPhotoRepository, never()).findBySpot(any());  // 기존 메서드는 호출되지 않아야 함
+            verify(spotRepository).delete(spot);
+
+            // afterCommit 발동 전에는 S3 호출 없음
+            verify(objectStorageService, never()).delete(anyString(), anyString());
+
+            // 동기화가 등록되었는지 확인 + 직접 afterCommit 트리거
+            List<TransactionSynchronization> syncs =
+                TransactionSynchronizationManager.getSynchronizations();
+            assertThat(syncs).hasSize(1);
+            given(s3Properties.getBucket()).willReturn(TEST_BUCKET);
+            syncs.get(0).afterCommit();
+
+            // afterCommit 후 S3 키마다 베스트 에포트 삭제 호출 확인
+            verify(objectStorageService).delete(TEST_BUCKET, S3_KEY_1);
+            verify(objectStorageService).delete(TEST_BUCKET, S3_KEY_2);
+        }
+
+        @Test
+        @DisplayName("S3 키가 없으면 afterCommit 동기화 등록도 안 됨")
+        void delete_whenNoPhotos_shouldNotRegisterAfterCommit() {
+            // Given
+            Spot spot = mock(Spot.class);
+            given(userRepository.findById(TEST_USER_ID)).willReturn(Optional.of(testUser));
+            given(spotRepository.findById(TEST_SPOT_ID)).willReturn(Optional.of(spot));
+            given(spot.getUser()).willReturn(testUser);
+            given(spotPhotoRepository.findFileUrlsBySpot(TEST_SPOT_ID)).willReturn(List.of());
+
+            // When
+            spotService.delete(TEST_USER_ID, TEST_SPOT_ID);
+
+            // Then
+            verify(spotRepository).delete(spot);
+            assertThat(TransactionSynchronizationManager.getSynchronizations()).isEmpty();
+            verify(objectStorageService, never()).delete(anyString(), anyString());
+        }
+
+        @Test
+        @DisplayName("사용자를 찾을 수 없으면 USER_NOT_FOUND 예외, Spot 조회·삭제 모두 호출되지 않음")
+        void delete_whenUserNotFound_shouldThrowUserNotFound() {
+            // Given
+            given(userRepository.findById(TEST_USER_ID)).willReturn(Optional.empty());
+
+            // When & Then
+            assertThatThrownBy(() -> spotService.delete(TEST_USER_ID, TEST_SPOT_ID))
+                .isInstanceOf(CommonException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.USER_NOT_FOUND);
+
+            verify(spotRepository, never()).findById(anyLong());
+            verify(spotRepository, never()).delete(any());
+            verify(spotPhotoRepository, never()).findFileUrlsBySpot(anyLong());
+            assertThat(TransactionSynchronizationManager.getSynchronizations()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("다른 사용자의 스팟 삭제 시도 시 ACCESS_DENIED 예외, Spot 삭제는 호출되지 않음")
+        void delete_whenNotOwner_shouldThrowAccessDenied() {
+            // Given
+            User otherOwner = mock(User.class);
+            Spot spot = mock(Spot.class);
+            given(userRepository.findById(TEST_USER_ID)).willReturn(Optional.of(testUser));
+            given(spotRepository.findById(TEST_SPOT_ID)).willReturn(Optional.of(spot));
+            given(spot.getUser()).willReturn(otherOwner);
+            given(otherOwner.getId()).willReturn(TEST_USER_ID + 999L);  // 다른 ID로 명시 stub (mock default null 회피)
+
+            // When & Then
+            assertThatThrownBy(() -> spotService.delete(TEST_USER_ID, TEST_SPOT_ID))
+                .isInstanceOf(CommonException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ACCESS_DENIED);
+
+            verify(spotRepository, never()).delete(any());
+            verify(spotPhotoRepository, never()).findFileUrlsBySpot(anyLong());
+            assertThat(TransactionSynchronizationManager.getSynchronizations()).isEmpty();
         }
     }
 }


### PR DESCRIPTION
## 요약
dev 환경에서 스팟 삭제(`DELETE /api/v1/spots/{spotId}`) 호출 시 발생하던 **`org.hibernate.TransientObjectException` 500 오류**를 해소하고, 스팟에 연결된 자식 4종(`SpotPhoto` / `SpotCheckin` / `SpotBookmark` / `SpotReport`)이 DB FK CASCADE로 일관 정리되도록 매핑·코드·운영 DDL을 함께 정비함. 외부 API 변경 없음.

<br>

## 작업 내용
- `SpotPhotoRepository.findFileUrlsBySpot(Long spotId)` JPQL projection 신규 — `SpotPhoto` 엔티티를 영속성 컨텍스트에 로드하지 않고 fileUrl만 추출해 flush 시 transient 참조 검사 회피
- `SpotCheckin` 엔티티의 `spot_id` / `photo_id` 양쪽에 `@OnDelete(action = OnDeleteAction.CASCADE)` 추가 (다른 자식 3종과 매핑 일관)
- `SpotService.delete` 본문 재구성
  - 자식 명시 삭제 호출 0건 — DB FK CASCADE에 일괄 위임
  - S3 객체 삭제를 `TransactionSynchronizationManager.registerSynchronization`의 `afterCommit`으로 이동 → DB rollback 시 S3 객체 보존
  - 소유권 검증을 `spot.getUser().getId().equals(userId)` ID 비교로 변경 (`User.equals` 미오버라이드 상태의 1차 캐시 의존 제거)
  - `User user` dead local 제거 — `findById(userId).orElseThrow(...)` 대입 없이 존재 검증만 수행
- `SpotServiceTest`에 `@Nested DeleteTests` 4건 신규 — `TransactionSynchronizationManager.initSynchronization`/`clearSynchronization`로 동기화 라이프사이클 직접 관리, afterCommit 등록·트리거까지 verify
- `SpotServiceDeleteIntegrationTest` 신규 — `@SpringBootTest` + `TestTransaction.flagForCommit/end` 기반으로 실제 commit 경로에서 `afterCommit` 발동되는지 검증. `SpotPhotoRepository`를 `@MockBean`으로 격리해 H2 spatial(`POINT SRID 4326`) 위험 회피

<br>

## 참고 사항
핵심 설계 결정
- **DB FK CASCADE 전면 의존**: 코드 간결성 + 운영 일관성 + 후속 user→자식 cascade 이슈와의 패턴 통일이 사유.
- **afterCommit 이동**: 기존 코드는 `spotRepository.delete(spot)` 직후 같은 트랜잭션 안에서 S3 호출 → DB commit 실패 시 S3 객체만 사라지는 정합성 결함이 있었음. `afterCommit`으로 옮겨 commit 성공 후에만 호출되도록 정리.
- **`Long spotId` 시그니처**: `findFileUrlsBySpot`을 `Spot` 엔티티 대신 `Long spotId`로 받아 의존 폭 축소.  

머지 전 가이드
- [x] **운영 DDL runbook 최종 점검** — `ALTER TABLE` SQL + orphan precheck + 실패 복구 SQL 사전 출력.
  - Hibernate `ddl-auto: update`는 기존 FK의 `ON DELETE` 옵션 변경을 자동 반영하지 않음. **운영/dev/staging DB 모두 수동 ALTER TABLE 1회 실행 필요**.

<br>

## 관련 이슈
- Closes #84
- Refs #38 

<br>