### PR TITLE
Fix(auth): 탈퇴 후 재로그인 시 GUEST 리셋 및 완전초기화 임시 비활성화

### DIFF
--- a/src/main/java/com/gemmap/gemmap/auth/application/service/AppleLoginTransactionService.java
+++ b/src/main/java/com/gemmap/gemmap/auth/application/service/AppleLoginTransactionService.java
@@ -81,7 +81,8 @@ public class AppleLoginTransactionService {
                 user.resetForRejoin();
                 log.info("Apple 재가입 — 유예 경과 초기화: socialId={}, originalDeleteDate={}", socialId, originalDeleteDate);
             } else {
-                log.info("Apple 재가입 — 유예 내 복구: socialId={}, originalDeleteDate={}", socialId, originalDeleteDate);
+                user.updateRole(ERole.GUEST);       // 유예 내 재가입도 회원가입 화면 재진입(role만 리셋, 그 외 데이터 보존)
+                log.info("Apple 재가입 — 유예 내 복구(GUEST 리셋): socialId={}, originalDeleteDate={}", socialId, originalDeleteDate);
             }
             return user;   // @Transactional 영속 컨텍스트가 변경 자동 반영
         }

--- a/src/main/java/com/gemmap/gemmap/auth/application/service/AuthService.java
+++ b/src/main/java/com/gemmap/gemmap/auth/application/service/AuthService.java
@@ -184,7 +184,8 @@ public class AuthService {
                 user.resetForRejoin();              // 마지막에 권한·임의 프로필 초기화
                 log.info("카카오 재가입 — 유예 경과 초기화: socialId={}, originalDeleteDate={}", socialId, originalDeleteDate);
             } else {
-                log.info("카카오 재가입 — 유예 내 복구: socialId={}, originalDeleteDate={}", socialId, originalDeleteDate);
+                user.updateRole(ERole.GUEST);       // 유예 내 재가입도 회원가입 화면 재진입(role만 리셋, 그 외 데이터 보존)
+                log.info("카카오 재가입 — 유예 내 복구(GUEST 리셋): socialId={}, originalDeleteDate={}", socialId, originalDeleteDate);
             }
             return userRepository.save(user);
         }

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -59,5 +59,6 @@ s3:
   checkin-base-path: "test/checkins/"
 
 # 회원 탈퇴 후 재가입 정책 (테스트용)
+# 실서비스 전 임시: 유예기간 사실상 무한대 → 경과 분기(resetForRejoin) 미도달. 실서비스 전환 시 30으로 복구.
 withdraw:
-  rejoin-grace-period-days: 30
+  rejoin-grace-period-days: 36500

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -53,7 +53,10 @@ crypto:
 
 # 회원 탈퇴 후 재가입 정책
 withdraw:
-  rejoin-grace-period-days: 30   # 탈퇴 후 N일 이내 재로그인 → 데이터 유지 복구. 경과 시 권한·프로필 초기화
+  # 탈퇴 후 N일 이내 재로그인 → 데이터 유지 복구(role=GUEST 리셋). 경과 시 resetForRejoin() 완전 초기화.
+  # [테스트용/임시] 실서비스 전 사용자 완전 탈퇴(데이터 초기화)가 실행되지 않도록 유예기간을 사실상 무한대(약 100년)로 둔다.
+  # → isGracePeriodExpired()가 항상 false → 경과 분기(resetForRejoin) 미도달. 실서비스 전환 시 30으로 복구.
+  rejoin-grace-period-days: 36500
 
 # AWS S3 설정
 s3:


### PR DESCRIPTION
## 요약
탈퇴 후 재로그인 시 `role`을 `GUEST`로 리셋해 항상 회원가입 화면을 한 번 거치도록 함.
실서비스 전 테스트 단계에서 "30일 경과 → 완전 초기화"가 실제 실행되지 않도록 유예기간을 임시로 무한대 설정.

<br>

## 작업 내용
- `AuthService.findOrCreateKakaoUser` / `AppleLoginTransactionService.findOrCreateAppleUser`의
  유예 내 재가입 분기에 `user.updateRole(ERole.GUEST)` 추가 (Kakao/Apple 동일)
- `role`만 리셋하고 `nickname`/`profileImage`/`photo_consent_agreed_at`/`email`/`name`은 보존
  → 회원가입 화면에 기존 값 prefill
- `withdraw.rejoin-grace-period-days` 30 → 36500 (`application.yml`, `application-test.yml`)
  → `isGracePeriodExpired()` 항상 false → 경과 분기(`resetForRejoin()`) 미도달 (로직 코드는 보존)

<br>

## 참고 사항
- **임시 설정**: `rejoin-grace-period-days: 36500`은 실서비스 전 테스트 보호용
  실서비스 전환 시 값만 `30`으로 복구하면 완전 초기화 분기가 코드 변경 없이 재활성화됨
- 신규 파일/엔드포인트/ErrorCode/DB 스키마 변경 0. `User.updateRole(ERole)` 기존 메서드 재사용
- 응답 JSON 구조 불변 (`role` 필드 값만 재로그인 시 GUEST로 반환) → 클라이언트 변경 없음
- 잔존 한계: `deleteDate=null` 비정상 데이터는 유예기간과 무관하게 expired로 간주(안전 fallback)
- 선행 작업: #80 (탈퇴 후 재로그인 버그 수정 — 30일 유예 정책)

<br>

## 관련 이슈
- Closes #86 
- Refs #80 (탈퇴 후 재로그인 버그 수정 — 30일 유예 정책)

<br>