### PR TITLE
Fix(auth): 탈퇴 요청 시 role을 GUEST로 강등

### DIFF
--- a/src/main/java/com/gemmap/gemmap/auth/application/service/AppleLoginTransactionService.java
+++ b/src/main/java/com/gemmap/gemmap/auth/application/service/AppleLoginTransactionService.java
@@ -81,8 +81,7 @@ public class AppleLoginTransactionService {
                 user.resetForRejoin();
                 log.info("Apple 재가입 — 유예 경과 초기화: socialId={}, originalDeleteDate={}", socialId, originalDeleteDate);
             } else {
-                user.updateRole(ERole.GUEST);       // 유예 내 재가입도 회원가입 화면 재진입(role만 리셋, 그 외 데이터 보존)
-                log.info("Apple 재가입 — 유예 내 복구(GUEST 리셋): socialId={}, originalDeleteDate={}", socialId, originalDeleteDate);
+                log.info("Apple 재가입 — 유예 내 복구: socialId={}, originalDeleteDate={}", socialId, originalDeleteDate);
             }
             return user;   // @Transactional 영속 컨텍스트가 변경 자동 반영
         }

--- a/src/main/java/com/gemmap/gemmap/auth/application/service/AuthService.java
+++ b/src/main/java/com/gemmap/gemmap/auth/application/service/AuthService.java
@@ -184,8 +184,7 @@ public class AuthService {
                 user.resetForRejoin();              // 마지막에 권한·임의 프로필 초기화
                 log.info("카카오 재가입 — 유예 경과 초기화: socialId={}, originalDeleteDate={}", socialId, originalDeleteDate);
             } else {
-                user.updateRole(ERole.GUEST);       // 유예 내 재가입도 회원가입 화면 재진입(role만 리셋, 그 외 데이터 보존)
-                log.info("카카오 재가입 — 유예 내 복구(GUEST 리셋): socialId={}, originalDeleteDate={}", socialId, originalDeleteDate);
+                log.info("카카오 재가입 — 유예 내 복구: socialId={}, originalDeleteDate={}", socialId, originalDeleteDate);
             }
             return userRepository.save(user);
         }

--- a/src/main/java/com/gemmap/gemmap/auth/domain/entity/User.java
+++ b/src/main/java/com/gemmap/gemmap/auth/domain/entity/User.java
@@ -182,6 +182,7 @@ public class User {
         this.deleteDate = LocalDate.now(KST);
         this.refreshToken = null;
         this.isLogin = false;
+        this.role = ERole.GUEST;   // 탈퇴 시 권한을 GUEST로 강등 → 재로그인 시 회원가입 화면 재진입
     }
 
     public void updateAppleRefreshToken(String encryptedRefreshToken) {


### PR DESCRIPTION
## 요약
회원 탈퇴 요청 시 사용자 권한을 GUEST로 강등하도록 변경. #87은 강등 시점을 "재로그인"으로 구현했으나, 요구사항은 "탈퇴 요청 시점" 강등이므로 시점을 이동하고 재로그인 GUEST 리셋은 원복. 사용자 관측 동작(재로그인 시 회원가입 화면 진입)은 동일.

<br>

## 작업 내용
- `User.withdrawUser()`에 `role = GUEST` 추가 → 탈퇴 데이터(is_deleted=true, delete_date, refresh_token=null, is_login=false)에 권한 강등 포함
- `AuthService.findOrCreateKakaoUser` / `AppleLoginTransactionService.findOrCreateAppleUser`의 재로그인 GUEST 리셋(#87) 제거 → #80 원래 동작 복귀
- `recoverUser()`는 role을 변경하지 않으므로, 탈퇴 시 강등된 GUEST가 재로그인 후에도 유지됨

<br>

## 참고 사항
- 신규 파일·ErrorCode·엔드포인트·DB 스키마 변경 0 (3 files, +3/-4). 응답 구조 불변(role 값만 GUEST)
- `rejoin-grace-period-days: 36500`(경과 분기 비활성화)는 본 변경 범위 밖 → 그대로 유지
- ⚠️ 이 코드 배포 이전에 탈퇴된 계정은 role=USER로 남아 신규 탈퇴부터 GUEST 적용 → 테스트 시 배포 후 재탈퇴 필요

<br>

## 관련 이슈
- Closes #86 
- Refs #87 (재로그인 접근 → 본 PR에서 탈퇴 시점으로 교정)

<br>