### PR TITLE
Feat(report): 신고 '기타' 사유 신고 내용 입력 선택사항화 (#90)

### DIFF
--- a/src/main/java/com/gemmap/gemmap/report/application/service/ReportService.java
+++ b/src/main/java/com/gemmap/gemmap/report/application/service/ReportService.java
@@ -53,7 +53,7 @@ public class ReportService {
                 .user(user)
                 .spot(spot)
                 .reason(request.reason())
-                .content(validateAndNormalizeContent(request.reason(), request.content()))
+                .content(normalizeContent(request.reason(), request.content()))
                 .build();
 
         try {
@@ -64,20 +64,14 @@ public class ReportService {
     }
 
     /**
-     * 신고 사유에 맞는 content 필수 여부와 저장값 형식을 함께 정리한다.
+     * 신고 사유에 맞는 저장용 content를 정리한다.
+     * OTHER 사유 + 내용이 있을 때만 trim 후 저장하고, 그 외에는 null로 정리한다.
+     * (OTHER 사유라도 내용은 선택 사항이다.)
      */
-    private String validateAndNormalizeContent(EReportReason reason, String content) {
-        // OTHER가 아닌 사유
-        if (reason != EReportReason.OTHER) {
-            return null; // content를 항상 null로 반환
+    private String normalizeContent(EReportReason reason, String content) {
+        if (reason != EReportReason.OTHER || !StringUtils.hasText(content)) {
+            return null;
         }
-
-        // OTHER 사유 + content 없음(null / 빈 문자열 / 공백만)
-        if (!StringUtils.hasText(content)) {
-            throw new CommonException(ErrorCode.REPORT_CONTENT_REQUIRED);
-        }
-
-        // OTHER 사유 + content 있음
         return content.trim();
     }
 }

--- a/src/main/java/com/gemmap/gemmap/shared/common/enums/EReportReason.java
+++ b/src/main/java/com/gemmap/gemmap/shared/common/enums/EReportReason.java
@@ -4,5 +4,5 @@ public enum EReportReason {
     LOCATION_MISMATCH,    // 사진과 입력된 위치가 달라요
     INAPPROPRIATE_PHOTO,  // 부적절한 사진이에요
     UNAUTHORIZED_PHOTO,   // 타인의 사진을 무단으로 사용했어요
-    OTHER                 // 기타 (content 필수)
+    OTHER                 // 기타 (content 선택 입력)
 }

--- a/src/main/java/com/gemmap/gemmap/shared/exception/ErrorCode.java
+++ b/src/main/java/com/gemmap/gemmap/shared/exception/ErrorCode.java
@@ -71,7 +71,6 @@ public enum ErrorCode {
     FILE_UPLOAD_FAILED(50020, HttpStatus.INTERNAL_SERVER_ERROR, "파일 업로드에 실패했습니다."),
     INVALID_FILE_FORMAT(40010, HttpStatus.BAD_REQUEST, "지원하지 않는 파일 형식입니다."),
     FILE_SIZE_EXCEEDED(40011, HttpStatus.BAD_REQUEST, "파일 크기가 너무 큽니다."),
-    REPORT_CONTENT_REQUIRED(40012, HttpStatus.BAD_REQUEST, "'기타' 사유 선택 시 신고 내용을 입력해야 합니다."),
     APPLE_REQUIRED_USER_INFO_MISSING(40013, HttpStatus.BAD_REQUEST, "Apple 최초 로그인에 필요한 사용자 정보가 누락되었습니다."),
 
     // OAuth2 관련 에러 (502 Bad Gateway - 외부 서비스 오류)

--- a/src/test/java/com/gemmap/gemmap/report/application/service/ReportServiceTest.java
+++ b/src/test/java/com/gemmap/gemmap/report/application/service/ReportServiceTest.java
@@ -135,18 +135,22 @@ class ReportServiceTest {
         }
 
         @Test
-        @DisplayName("OTHER 사유에 content가 없으면 REPORT_CONTENT_REQUIRED 예외")
-        void createReport_blankOtherContentThrowsBadRequest() {
+        @DisplayName("OTHER 사유에 content가 없으면 null로 저장한다")
+        void createReport_blankOtherContentSavesNull() {
             mockUserAndSpotFound();
             given(spotReportRepository.existsByUserAndSpot(user, spot)).willReturn(false);
 
-            assertThatThrownBy(() -> reportService.createReport(
+            ArgumentCaptor<SpotReport> reportCaptor = ArgumentCaptor.forClass(SpotReport.class);
+            given(spotReportRepository.save(reportCaptor.capture()))
+                    .willAnswer(invocation -> invocation.getArgument(0));
+
+            reportService.createReport(
                     TEST_USER_ID,
                     TEST_SPOT_ID,
                     new SpotReportRequest(EReportReason.OTHER, "   ")
-            ))
-                    .isInstanceOf(CommonException.class)
-                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.REPORT_CONTENT_REQUIRED);
+            );
+
+            assertThat(reportCaptor.getValue().getContent()).isNull();
         }
 
         @Test


### PR DESCRIPTION
## 요약
스팟 신고에서 '기타(OTHER)' 사유 선택 시 신고 내용(content) 입력을 필수 → 선택으로 완화함.  
'기타'를 골랐지만 적을 내용이 없는 사용자도 신고를 완료할 수 있음.

<br>

## 작업 내용
- `ReportService`: OTHER + 빈 내용일 때 예외를 던지던 분기 제거 → content 없이 접수 시 `content=null` 저장
- 메서드 rename: `validateAndNormalizeContent` → `normalizeContent` (예외 책임 소멸로 이름 정정)
- 미사용이 된 `ErrorCode.REPORT_CONTENT_REQUIRED(40012)` 제거
- 단위 테스트 교체: "OTHER 빈 내용 → 예외" → "OTHER 빈 내용 → null 저장 성공"

<br>

## 참고 사항
- 유일한 동작 변경점: `OTHER + 내용 없음` → 기존 400(40012)에서 **201 정상 접수**로 변경
- 요청/응답 JSON 구조, 엔드포인트, DB 스키마 변경 없음 (`content` 컬럼은 이미 nullable)
- ErrorCode 40012만 라인 삭제, 다른 40000번대 번호는 재정렬하지 않음 (호환성)
- `ReportServiceTest` 6/6 통과

<br>

## 관련 이슈
- Closes #90
- Refs #68 

<br>